### PR TITLE
Fixed typo "enviroment" in gen-qa-openai.ipynb

### DIFF
--- a/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai.ipynb
+++ b/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai.ipynb
@@ -574,7 +574,7 @@
         "# find your environment next to the api key in pinecone console\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)\n",
+        "pinecone.init(api_key=api_key, environment=env)\n",
         "pinecone.whoami()"
       ]
     },


### PR DESCRIPTION
"enviroment" -> "environment"