### PR TITLE
added new semantic search notebooks

### DIFF
--- a/search/semantic-search/semantic-search-fast.ipynb
+++ b/search/semantic-search/semantic-search-fast.ipynb
@@ -1,0 +1,1388 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "02b5b807868040199bc71122625c6926": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_6fa7dd582c9c4d909fcb94ac182f57c6",
+              "IPY_MODEL_e6ea0040b1a043abaca42f61b9517642",
+              "IPY_MODEL_38f6aa81c5fb42399a52b394cf869c51"
+            ],
+            "layout": "IPY_MODEL_2c119b912e9141518a9a5b01550235d9"
+          }
+        },
+        "6fa7dd582c9c4d909fcb94ac182f57c6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_d8a9deaef40f42b7bdf571d61b81e805",
+            "placeholder": "​",
+            "style": "IPY_MODEL_c7d8ec2f92e9468b900298abd46cdf79",
+            "value": "sending upsert requests: 100%"
+          }
+        },
+        "e6ea0040b1a043abaca42f61b9517642": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_344784dc4cf541e58817a2d838b8ddc4",
+            "max": 522931,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_bbafd18666ab489297af3706fd3bb4f5",
+            "value": 522931
+          }
+        },
+        "38f6aa81c5fb42399a52b394cf869c51": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a76dc32d38584caab88d7c9aed162531",
+            "placeholder": "​",
+            "style": "IPY_MODEL_567333a30e3e41d3b50419f767d7ae5d",
+            "value": " 522931/522931 [00:58&lt;00:00, 6982.34it/s]"
+          }
+        },
+        "2c119b912e9141518a9a5b01550235d9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d8a9deaef40f42b7bdf571d61b81e805": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c7d8ec2f92e9468b900298abd46cdf79": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "344784dc4cf541e58817a2d838b8ddc4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bbafd18666ab489297af3706fd3bb4f5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "a76dc32d38584caab88d7c9aed162531": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "567333a30e3e41d3b50419f767d7ae5d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "0a6dd0f9071844e59f3c56fbcf6dc85c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_4b58f25e0d3d449299bf1d02e8987dab",
+              "IPY_MODEL_459f16f800eb4cb98139ca8dd3723bd8",
+              "IPY_MODEL_0946ca47f88647aeb60aa9de2b5bbb58"
+            ],
+            "layout": "IPY_MODEL_cdb038343cf24c9180946b8a27ffa12e"
+          }
+        },
+        "4b58f25e0d3d449299bf1d02e8987dab": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_874d523afa424ae1b0ebe47586db8389",
+            "placeholder": "​",
+            "style": "IPY_MODEL_8321c8cc5749463f85be8b1682c412ae",
+            "value": "collecting async responses: 100%"
+          }
+        },
+        "459f16f800eb4cb98139ca8dd3723bd8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_2827a9c755f944319ba6dc46a9524712",
+            "max": 1046,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_b940afcfb835462682011c64a89cc7b0",
+            "value": 1046
+          }
+        },
+        "0946ca47f88647aeb60aa9de2b5bbb58": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_4d95073857b34496b4f94f8fd6c8d78d",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5acb3a8a9157425996f097278045d315",
+            "value": " 1046/1046 [00:00&lt;00:00, 6602.83it/s]"
+          }
+        },
+        "cdb038343cf24c9180946b8a27ffa12e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "874d523afa424ae1b0ebe47586db8389": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8321c8cc5749463f85be8b1682c412ae": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "2827a9c755f944319ba6dc46a9524712": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b940afcfb835462682011c64a89cc7b0": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "4d95073857b34496b4f94f8fd6c8d78d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5acb3a8a9157425996f097278045d315": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    },
+    "accelerator": "GPU",
+    "gpuClass": "standard"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/search/semantic-search/semantic-search-fast.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/pinecone-io/examples/blob/master/search/semantic-search/semantic-search-fast.ipynb)\n",
+        "\n",
+        "# Semantic Search (Fast)\n",
+        "\n",
+        "In this walkthrough we will see how to use Pinecone for semantic search. To begin we must install the required prerequisite libraries:"
+      ],
+      "metadata": {
+        "id": "k7Lc9I6taO3k"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -qU pinecone-client[grpc] pinecone-datasets sentence-transformers"
+      ],
+      "metadata": {
+        "id": "q03L1BYEZQfe",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "1ba5b4f8-e16f-472f-fc96-d7660dd12fb8"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m177.2/177.2 kB\u001b[0m \u001b[31m1.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m86.0/86.0 kB\u001b[0m \u001b[31m2.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m283.7/283.7 kB\u001b[0m \u001b[31m20.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.0/60.0 kB\u001b[0m \u001b[31m1.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m7.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.1 MB\u001b[0m \u001b[31m20.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m34.9/34.9 MB\u001b[0m \u001b[31m16.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.4/16.4 MB\u001b[0m \u001b[31m81.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.0/7.0 MB\u001b[0m \u001b[31m107.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m81.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m200.1/200.1 kB\u001b[0m \u001b[31m27.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/1.0 MB\u001b[0m \u001b[31m71.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m223.0/223.0 kB\u001b[0m \u001b[31m31.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m218.0/218.0 kB\u001b[0m \u001b[31m29.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m218.0/218.0 kB\u001b[0m \u001b[31m28.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m211.7/211.7 kB\u001b[0m \u001b[31m29.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m72.7/72.7 kB\u001b[0m \u001b[31m9.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m116.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m10.4/10.4 MB\u001b[0m \u001b[31m118.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m264.6/264.6 kB\u001b[0m \u001b[31m2.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m114.2/114.2 kB\u001b[0m \u001b[31m17.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m158.8/158.8 kB\u001b[0m \u001b[31m22.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.6/115.6 kB\u001b[0m \u001b[31m17.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.5/115.5 kB\u001b[0m \u001b[31m18.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.3/115.3 kB\u001b[0m \u001b[31m17.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.1/115.1 kB\u001b[0m \u001b[31m18.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m114.6/114.6 kB\u001b[0m \u001b[31m18.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for sentence-transformers (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "tensorflow 2.12.0 requires protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.20.3, but you have protobuf 3.19.3 which is incompatible.\n",
+            "tensorflow-hub 0.13.0 requires protobuf>=3.19.6, but you have protobuf 3.19.3 which is incompatible.\n",
+            "tensorboard 2.12.1 requires protobuf>=3.19.6, but you have protobuf 3.19.3 which is incompatible.\n",
+            "pandas-gbq 0.17.9 requires pyarrow<10.0dev,>=3.0.0, but you have pyarrow 11.0.0 which is incompatible.\n",
+            "google-cloud-translate 3.11.1 requires google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0, but you have google-api-core 2.8.2 which is incompatible.\n",
+            "google-cloud-translate 3.11.1 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\n",
+            "google-cloud-language 2.9.1 requires google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0, but you have google-api-core 2.8.2 which is incompatible.\n",
+            "google-cloud-language 2.9.1 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\n",
+            "google-cloud-firestore 2.11.0 requires google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0, but you have google-api-core 2.8.2 which is incompatible.\n",
+            "google-cloud-firestore 2.11.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\n",
+            "google-cloud-datastore 2.15.1 requires google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0, but you have google-api-core 2.8.2 which is incompatible.\n",
+            "google-cloud-datastore 2.15.1 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\n",
+            "google-cloud-bigquery 3.9.0 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\n",
+            "google-cloud-bigquery-storage 2.19.1 requires google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0, but you have google-api-core 2.8.2 which is incompatible.\n",
+            "google-cloud-bigquery-storage 2.19.1 requires protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5, but you have protobuf 3.19.3 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0m"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Data Preprocessing"
+      ],
+      "metadata": {
+        "id": "hrSfFiIC5roI"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The dataset preparation process requires a few steps:\n",
+        "\n",
+        "1. We download the Quora dataset from Hugging Face Datasets.\n",
+        "\n",
+        "2. The text content of the dataset is embedded into vectors.\n",
+        "\n",
+        "3. We reformat into a `(id, vector, metadata)` structure to be added to Pinecone.\n",
+        "\n",
+        "In this notebook we will skip these three steps as they can be very time consuming and jump straight into it with the prebuilt dataset from *Pinecone Datasets*. If you'd rather see how it's all done, please refer to [this notebook](https://github.com/pinecone-io/examples/blob/master/search/semantic-search/semantic-search.ipynb).\n",
+        "\n",
+        "Let's go ahead and download the dataset."
+      ],
+      "metadata": {
+        "id": "kujS_e8s55oJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pinecone_datasets import load_dataset\n",
+        "\n",
+        "dataset = load_dataset('quora_all-MiniLM-L6-bm25')\n",
+        "# we drop sparse_values as they are not needed for this example\n",
+        "dataset.documents.drop(['sparse_values', 'metadata'], axis=1, inplace=True)\n",
+        "dataset.documents.rename(columns={'blob': 'metadata'}, inplace=True)\n",
+        "dataset.head()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 206
+        },
+        "id": "lOgjRG52Zqqz",
+        "outputId": "16b04473-284c-48fa-8373-69f58ad25a2c"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "  id                                             values  \\\n",
+              "0  1  [0.06814987, -0.039664183, -0.06096721, 0.0074...   \n",
+              "1  2  [0.08983771, -0.03493085, -0.057357617, 0.0222...   \n",
+              "2  3  [-0.046798065, 0.1551149, -0.03920019, 0.04878...   \n",
+              "3  4  [-0.077349104, 0.14786911, -0.0128817065, -0.0...   \n",
+              "4  5  [-0.028324936, 0.037209604, -0.00040033547, 0....   \n",
+              "\n",
+              "                                            metadata  \n",
+              "0  {'text': ' What is the step by step guide to i...  \n",
+              "1  {'text': ' What is the step by step guide to i...  \n",
+              "2  {'text': ' What is the story of Kohinoor (Koh-...  \n",
+              "3  {'text': ' What would happen if the Indian gov...  \n",
+              "4  {'text': ' How can I increase the speed of my ...  "
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-379cbe01-7fef-4af5-a439-a5830f608af7\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>id</th>\n",
+              "      <th>values</th>\n",
+              "      <th>metadata</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>1</td>\n",
+              "      <td>[0.06814987, -0.039664183, -0.06096721, 0.0074...</td>\n",
+              "      <td>{'text': ' What is the step by step guide to i...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>2</td>\n",
+              "      <td>[0.08983771, -0.03493085, -0.057357617, 0.0222...</td>\n",
+              "      <td>{'text': ' What is the step by step guide to i...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>3</td>\n",
+              "      <td>[-0.046798065, 0.1551149, -0.03920019, 0.04878...</td>\n",
+              "      <td>{'text': ' What is the story of Kohinoor (Koh-...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>4</td>\n",
+              "      <td>[-0.077349104, 0.14786911, -0.0128817065, -0.0...</td>\n",
+              "      <td>{'text': ' What would happen if the Indian gov...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>5</td>\n",
+              "      <td>[-0.028324936, 0.037209604, -0.00040033547, 0....</td>\n",
+              "      <td>{'text': ' How can I increase the speed of my ...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-379cbe01-7fef-4af5-a439-a5830f608af7')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "        \n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "      \n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-379cbe01-7fef-4af5-a439-a5830f608af7 button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-379cbe01-7fef-4af5-a439-a5830f608af7');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n",
+              "  "
+            ]
+          },
+          "metadata": {},
+          "execution_count": 2
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Creating an Index\n",
+        "\n",
+        "Now the data is ready, we can set up our index to store it.\n",
+        "\n",
+        "We begin by initializing our connection to Pinecone. To do this we need a [free API key](https://app.pinecone.io)."
+      ],
+      "metadata": {
+        "id": "ebd7XSamfMsC"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import os\n",
+        "import pinecone\n",
+        "\n",
+        "# get api key from app.pinecone.io\n",
+        "PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY') or 'PINECONE_API_KEY'\n",
+        "# find your environment next to the api key in pinecone console\n",
+        "PINECONE_ENV = os.environ.get('PINECONE_ENVIRONMENT') or 'PINECONE_ENVIRONMENT'\n",
+        "\n",
+        "pinecone.init(\n",
+        "    api_key=PINECONE_API_KEY,\n",
+        "    environment=PINECONE_ENV\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "mc66NEBAcQHY",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "053d2126-43b1-4c84-cf29-834e3e5abc93"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.9/dist-packages/pinecone/index.py:4: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+            "  from tqdm.autonotebook import tqdm\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now we create a new index called `semantic-search-fast`. It's important that we align the index `dimension` and `metric` parameters with those required by the `MiniLM-L6` model."
+      ],
+      "metadata": {
+        "id": "SdaTip6CfllN"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "index_name = 'semantic-search-fast'\n",
+        "\n",
+        "# only create index if it doesn't exist\n",
+        "if index_name not in pinecone.list_indexes():\n",
+        "    pinecone.create_index(\n",
+        "        name=index_name,\n",
+        "        dimension=len(dataset.documents.iloc[0]['values']),\n",
+        "        metric='cosine'\n",
+        "    )\n",
+        "\n",
+        "# now connect to the index\n",
+        "index = pinecone.GRPCIndex(index_name)"
+      ],
+      "metadata": {
+        "id": "p1pyQh8gfm2-"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Upsert the data:"
+      ],
+      "metadata": {
+        "id": "YUd1VGg6i108"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "index.upsert_from_dataframe(dataset.documents)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 99,
+          "referenced_widgets": [
+            "02b5b807868040199bc71122625c6926",
+            "6fa7dd582c9c4d909fcb94ac182f57c6",
+            "e6ea0040b1a043abaca42f61b9517642",
+            "38f6aa81c5fb42399a52b394cf869c51",
+            "2c119b912e9141518a9a5b01550235d9",
+            "d8a9deaef40f42b7bdf571d61b81e805",
+            "c7d8ec2f92e9468b900298abd46cdf79",
+            "344784dc4cf541e58817a2d838b8ddc4",
+            "bbafd18666ab489297af3706fd3bb4f5",
+            "a76dc32d38584caab88d7c9aed162531",
+            "567333a30e3e41d3b50419f767d7ae5d",
+            "0a6dd0f9071844e59f3c56fbcf6dc85c",
+            "4b58f25e0d3d449299bf1d02e8987dab",
+            "459f16f800eb4cb98139ca8dd3723bd8",
+            "0946ca47f88647aeb60aa9de2b5bbb58",
+            "cdb038343cf24c9180946b8a27ffa12e",
+            "874d523afa424ae1b0ebe47586db8389",
+            "8321c8cc5749463f85be8b1682c412ae",
+            "2827a9c755f944319ba6dc46a9524712",
+            "b940afcfb835462682011c64a89cc7b0",
+            "4d95073857b34496b4f94f8fd6c8d78d",
+            "5acb3a8a9157425996f097278045d315"
+          ]
+        },
+        "id": "RhR6WOi1huXZ",
+        "outputId": "dc0e4d32-911f-436e-cb5d-23c430b97856"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "sending upsert requests:   0%|          | 0/522931 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "02b5b807868040199bc71122625c6926"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "collecting async responses:   0%|          | 0/1046 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "0a6dd0f9071844e59f3c56fbcf6dc85c"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "upserted_count: 522931"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 6
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Making Queries"
+      ],
+      "metadata": {
+        "id": "VrK_IN079Vuu"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now that our index is populated we can begin making queries. We are performing a semantic search for *similar questions*, so we should embed and search with another question. Let's begin."
+      ],
+      "metadata": {
+        "id": "rr4unPAq9alb"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from sentence_transformers import SentenceTransformer\n",
+        "import torch\n",
+        "\n",
+        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+        "\n",
+        "model = SentenceTransformer('all-MiniLM-L6-v2', device=device)\n",
+        "model"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Fqo_hMRZiubM",
+        "outputId": "9e3ed830-d812-4e56-c37e-f87c3af248c6"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "SentenceTransformer(\n",
+              "  (0): Transformer({'max_seq_length': 256, 'do_lower_case': False}) with Transformer model: BertModel \n",
+              "  (1): Pooling({'word_embedding_dimension': 384, 'pooling_mode_cls_token': False, 'pooling_mode_mean_tokens': True, 'pooling_mode_max_tokens': False, 'pooling_mode_mean_sqrt_len_tokens': False})\n",
+              "  (2): Normalize()\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {
+        "id": "MP2-unZ--XJ9"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "query = \"which city has the highest population in the world?\"\n",
+        "\n",
+        "# create the query vector\n",
+        "xq = model.encode(query).tolist()\n",
+        "\n",
+        "# now query\n",
+        "xc = index.query(xq, top_k=3, include_metadata=True)\n",
+        "xc"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JWcO7jAK-N_1",
+        "outputId": "fec43a38-8962-424e-f17d-f6264f7fbbd2"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'matches': [{'id': '210880',\n",
+              "              'metadata': {'text': ' Which is the most populated city in the '\n",
+              "                                   'world.?'},\n",
+              "              'score': 0.88284826,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []},\n",
+              "             {'id': '197238',\n",
+              "              'metadata': {'text': ' What is the most populated city in the '\n",
+              "                                   'world?'},\n",
+              "              'score': 0.8788713,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []},\n",
+              "             {'id': '239582',\n",
+              "              'metadata': {'text': ' Which is the largest city in the world?'},\n",
+              "              'score': 0.81348896,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []}],\n",
+              " 'namespace': ''}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In the returned response `xc` we can see the most relevant questions to our particular query. We can reformat this response to be a little easier to read:"
+      ],
+      "metadata": {
+        "id": "-XwOWcgo_QtI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "for result in xc['matches']:\n",
+        "    print(f\"{round(result['score'], 2)}: {result['metadata']['text']}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gy7isg_f-vWg",
+        "outputId": "9ce8117a-00f1-4da2-9b27-2776b09f04ae"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "0.88:  Which is the most populated city in the world.?\n",
+            "0.88:  What is the most populated city in the world?\n",
+            "0.81:  Which is the largest city in the world?\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "These are clearly very relevant results. All of these questions either share the exact same meaning as our question, or are related. We can make this harder by using more complicated language, but as long as the \"meaning\" behind our query remains the same, we should see similar results."
+      ],
+      "metadata": {
+        "id": "1JK5yApl_5fE"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "query = \"which urban locations have the highest concentration of homo sapiens?\"\n",
+        "\n",
+        "# create the query vector\n",
+        "xq = model.encode(query).tolist()\n",
+        "\n",
+        "# now query\n",
+        "xc = index.query(xq, top_k=3, include_metadata=True)\n",
+        "for result in xc['matches']:\n",
+        "    print(f\"{round(result['score'], 2)}: {result['metadata']['text']}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dJbjE-iq_yMr",
+        "outputId": "fcc0319d-cc2a-4c53-d4de-caa384b7266e"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "0.62:  Which is the most populated city in the world.?\n",
+            "0.62:  What is the most populated city in the world?\n",
+            "0.61:  What are the world's most advanced cities?\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Here we used *very different* language with completely different terms in our query than that of the returned documents. We substituted **\"city\"** for **\"urban location\"** and **\"populated\"** for **\"concentration of homo sapiens\"**.\n",
+        "\n",
+        "Despite these very different terms and *lack* of term overlap between query and returned documents — we get highly relevant results — this is the power of *semantic search*.\n",
+        "\n",
+        "You can go ahead and ask more questions above. When you're done, delete the index to save resources:"
+      ],
+      "metadata": {
+        "id": "HIAxOPb-A2w_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pinecone.delete_index(index_name)"
+      ],
+      "metadata": {
+        "id": "-cWdeKzhAtww"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "---"
+      ],
+      "metadata": {
+        "id": "2B0zxR6hbf5d"
+      }
+    }
+  ]
+}

--- a/search/semantic-search/semantic-search.ipynb
+++ b/search/semantic-search/semantic-search.ipynb
@@ -1,0 +1,1018 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W390nLBmZlId"
+      },
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/search/semantic-search/semantic-search.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/pinecone-io/examples/blob/master/search/semantic-search/semantic-search.ipynb)\n",
+        "\n",
+        "# Semantic Search\n",
+        "\n",
+        "In this walkthrough we will see how to use Pinecone for semantic search. To begin we must install the required prerequisite libraries:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "q03L1BYEZQfe"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -qU pinecone-client[grpc] datasets sentence-transformers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hrSfFiIC5roI"
+      },
+      "source": [
+        "## Data Preprocessing"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kujS_e8s55oJ"
+      },
+      "source": [
+        "The dataset preparation process requires a few steps:\n",
+        "\n",
+        "1. We download the Quora dataset from Hugging Face Datasets.\n",
+        "\n",
+        "2. The text content of the dataset is embedded into vectors.\n",
+        "\n",
+        "3. We reformat into a `(id, vector, metadata)` structure to be added to Pinecone.\n",
+        "\n",
+        "We will see how steps `1`, `2`, and `3` are done in this section, but we won't implement `2` and `3` across the whole dataset until we reach the *upsert loop* as we will iteratively perform these two steps.\n",
+        "\n",
+        "In either case, this can take some time. If you'd rather skip the data preparation step and get straight to upserts and testing the semantic search functionality, you should \n",
+        "refer to the [**fast notebook**](https://github.com/pinecone-io/examples/blob/master/search/semantic-search/semantic-search-fast.ipynb)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "IeJPWu9P7EtR",
+        "outputId": "3329d7d5-6de3-4664-a095-3158bf3832ff"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:datasets.builder:Found cached dataset quora (/root/.cache/huggingface/datasets/quora/default/0.0.0/36ba4cd42107f051a158016f1bea6ae3f4685c5df843529108a54e42d86c1e04)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Dataset({\n",
+              "    features: ['questions', 'is_duplicate'],\n",
+              "    num_rows: 404290\n",
+              "})"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from datasets import load_dataset\n",
+        "\n",
+        "dataset = load_dataset('quora', split='train')\n",
+        "dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ngFHND1nQQU2"
+      },
+      "source": [
+        "The dataset contains ~400K pairs of natural language questions from Quora."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CsA67WpW7El4",
+        "outputId": "4d93f186-20d5-4af4-e353-603400d4cca5"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'questions': [{'id': [1, 2],\n",
+              "   'text': ['What is the step by step guide to invest in share market in india?',\n",
+              "    'What is the step by step guide to invest in share market?']},\n",
+              "  {'id': [3, 4],\n",
+              "   'text': ['What is the story of Kohinoor (Koh-i-Noor) Diamond?',\n",
+              "    'What would happen if the Indian government stole the Kohinoor (Koh-i-Noor) diamond back?']},\n",
+              "  {'id': [5, 6],\n",
+              "   'text': ['How can I increase the speed of my internet connection while using a VPN?',\n",
+              "    'How can Internet speed be increased by hacking through DNS?']},\n",
+              "  {'id': [7, 8],\n",
+              "   'text': ['Why am I mentally very lonely? How can I solve it?',\n",
+              "    'Find the remainder when [math]23^{24}[/math] is divided by 24,23?']},\n",
+              "  {'id': [9, 10],\n",
+              "   'text': ['Which one dissolve in water quikly sugar, salt, methane and carbon di oxide?',\n",
+              "    'Which fish would survive in salt water?']}],\n",
+              " 'is_duplicate': [False, False, False, False, False]}"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dataset[:5]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H_Zy8zoeQmRZ"
+      },
+      "source": [
+        "Whether or not the questions are duplicates is not so important, all we need for this example is the text itself. We can extract them all into a single `questions` list."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "heGUpy_37Eis",
+        "outputId": "8de3ef1b-5ff3-4ee2-8e7c-d1a35ba2d250"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "How do I write an essay in 200 words for placement test?\n",
+            "How do actors learn accents?\n",
+            "What are crime control policies? What are examples?\n",
+            "How can a small company grow big?\n",
+            "537362\n"
+          ]
+        }
+      ],
+      "source": [
+        "questions = []\n",
+        "\n",
+        "for record in dataset['questions']:\n",
+        "    questions.extend(record['text'])\n",
+        "  \n",
+        "# remove duplicates\n",
+        "questions = list(set(questions))\n",
+        "print('\\n'.join(questions[:5]))\n",
+        "print(len(questions))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4BknpfucRkkm"
+      },
+      "source": [
+        "With our questions ready to go we can move on to demoing steps **2** and **3** above.\n",
+        "\n",
+        "### Building Embeddings and Upsert Format\n",
+        "\n",
+        "To create our embeddings we will us the `MiniLM-L6` sentence transformer model. This is a very efficient semantic similarity embedding model from the `sentence-transformers` library. We initialize it like so:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "uxcGjb9GSEqA",
+        "outputId": "8ada0184-b36c-4e8c-cb1d-5bf915e8eccf"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "SentenceTransformer(\n",
+              "  (0): Transformer({'max_seq_length': 256, 'do_lower_case': False}) with Transformer model: BertModel \n",
+              "  (1): Pooling({'word_embedding_dimension': 384, 'pooling_mode_cls_token': False, 'pooling_mode_mean_tokens': True, 'pooling_mode_max_tokens': False, 'pooling_mode_mean_sqrt_len_tokens': False})\n",
+              "  (2): Normalize()\n",
+              ")"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from sentence_transformers import SentenceTransformer\n",
+        "import torch\n",
+        "\n",
+        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+        "if device != 'cuda':\n",
+        "    print(f\"You are using {device}. This is much slower than using \"\n",
+        "          \"a CUDA-enabled GPU. If on Colab you can change this by \"\n",
+        "          \"clicking Runtime > Change runtime type > GPU.\")\n",
+        "\n",
+        "model = SentenceTransformer('all-MiniLM-L6-v2', device=device)\n",
+        "model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iy2itPb0S5js"
+      },
+      "source": [
+        "There are *three* interesting bits of information in the above model printout. Those are:\n",
+        "\n",
+        "* `max_seq_length` is `256`. That means that the maximum number of tokens (like words) that can be encoded into a single vector embedding is `256`. Anything beyond this *must* be truncated.\n",
+        "\n",
+        "* `word_embedding_dimension` is `384`. This number is the dimensionality of vectors output by this model. It is important that we know this number later when initializing our Pinecone vector index.\n",
+        "\n",
+        "* `Normalize()`. This final normalization step indicates that all vectors produced by the model are normalized. That means that models that we would typical measure similarity for using *cosine similarity* can also make use of the *dotproduct* similarity metric. In fact, with normalized vectors *cosine* and *dotproduct* are equivalent.\n",
+        "\n",
+        "Moving on, we can create a sentence embedding using this model like so:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dyzoJEsAULOe",
+        "outputId": "c916cf83-5545-458c-95a7-e0dcdc881ce7"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(384,)"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "query = 'which city is the most populated in the world?'\n",
+        "\n",
+        "xq = model.encode(query)\n",
+        "xq.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qVZi8xevUWM6"
+      },
+      "source": [
+        "Encoding this single sentence leaves us with a `384` dimensional sentence embedding (aligned to the `word_embedding_dimension` above).\n",
+        "\n",
+        "To prepare this for `upsert` to Pinecone, all we do is this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "T38HdqxwVg6p"
+      },
+      "outputs": [],
+      "source": [
+        "_id = '0'\n",
+        "metadata = {'text': query}\n",
+        "\n",
+        "vectors = [(_id, xq, metadata)]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wiXig_rHV2Wz"
+      },
+      "source": [
+        "Later when we do upsert our data to Pinecone, we will be doing so in batches. Meaning `vectors` will be a list of `(id, embedding, metadata)` tuples."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ebd7XSamfMsC"
+      },
+      "source": [
+        "## Creating an Index\n",
+        "\n",
+        "Now the data is ready, we can set up our index to store it.\n",
+        "\n",
+        "We begin by initializing our connection to Pinecone. To do this we need a [free API key](https://app.pinecone.io)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "mc66NEBAcQHY"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import pinecone\n",
+        "\n",
+        "# get api key from app.pinecone.io\n",
+        "PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY') or 'PINECONE_API_KEY'\n",
+        "# find your environment next to the api key in pinecone console\n",
+        "PINECONE_ENV = os.environ.get('PINECONE_ENVIRONMENT') or 'PINECONE_ENVIRONMENT'\n",
+        "\n",
+        "pinecone.init(\n",
+        "    api_key=PINECONE_API_KEY,\n",
+        "    environment=PINECONE_ENV\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SdaTip6CfllN"
+      },
+      "source": [
+        "Now we create a new index called `semantic-search`. It's important that we align the index `dimension` and `metric` parameters with those required by the `MiniLM-L6` model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "p1pyQh8gfm2-"
+      },
+      "outputs": [],
+      "source": [
+        "index_name = 'semantic-search-fast'\n",
+        "\n",
+        "# only create index if it doesn't exist\n",
+        "if index_name not in pinecone.list_indexes():\n",
+        "    pinecone.create_index(\n",
+        "        name=index_name,\n",
+        "        dimension=model.get_sentence_embedding_dimension(),\n",
+        "        metric='cosine'\n",
+        "    )\n",
+        "\n",
+        "# now connect to the index\n",
+        "index = pinecone.GRPCIndex(index_name)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YUd1VGg6i108"
+      },
+      "source": [
+        "Now we upsert the data, we will do this in batches of `128`.\n",
+        "\n",
+        "_**Note:** On Google Colab with GPU expected runtime is ~7 minutes. If using CPU this will be significantly longer. If you'd like to get this running faster refer to the [fast notebook](https://github.com/pinecone-io/examples/blob/master/search/semantic-search/semantic-search-fast.ipynb)._"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 120,
+          "referenced_widgets": [
+            "88279982dc91433a9ca6ab566c66d165",
+            "a42ac37b6dae48549dec3028ce1c1556",
+            "6f6c54d7b46242e2a1241e3d722713d3",
+            "b1580f14f23b4f9499d914e9dc10b8c8",
+            "7f2c61243d0542ef8ea8ab6683f16697",
+            "dd760ee9cf9c4444beef229d64f906a2",
+            "cd296bc17dbb47248eea1ec2ab6d5ab6",
+            "880d7798b2c14ef6a19723f2e1b5cc12",
+            "6ba5e03b6ed74eaf98bcf2073e6475b0",
+            "d2a1d064c0464b43bc85b3a00df00879",
+            "29f86af39ebc4c588402c560e0793962"
+          ]
+        },
+        "id": "RhR6WOi1huXZ",
+        "outputId": "924fd1c9-b4e0-4bff-dae2-557303c99642"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "88279982dc91433a9ca6ab566c66d165",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "  0%|          | 0/4199 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{'dimension': 384,\n",
+              " 'index_fullness': 0.4,\n",
+              " 'namespaces': {'': {'vector_count': 537919}},\n",
+              " 'total_vector_count': 537919}"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from tqdm.auto import tqdm\n",
+        "\n",
+        "batch_size = 128\n",
+        "\n",
+        "for i in tqdm(range(0, len(questions), batch_size)):\n",
+        "    # find end of batch\n",
+        "    i_end = min(i+batch_size, len(questions))\n",
+        "    # create IDs batch\n",
+        "    ids = [str(x) for x in range(i, i_end)]\n",
+        "    # create metadata batch\n",
+        "    metadatas = [{'text': text} for text in questions[i:i_end]]\n",
+        "    # create embeddings\n",
+        "    xc = model.encode(questions[i:i_end])\n",
+        "    # create records list for upsert\n",
+        "    records = zip(ids, xc, metadatas)\n",
+        "    # upsert to Pinecone\n",
+        "    index.upsert(vectors=records)\n",
+        "\n",
+        "# check number of records in the index\n",
+        "index.describe_index_stats()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VrK_IN079Vuu"
+      },
+      "source": [
+        "## Making Queries"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rr4unPAq9alb"
+      },
+      "source": [
+        "Now that our index is populated we can begin making queries. We are performing a semantic search for *similar questions*, so we should embed and search with another question. Let's begin."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JWcO7jAK-N_1",
+        "outputId": "d66adbbd-37a5-41f5-cf3b-4fe6314c271b"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'matches': [{'id': '229220',\n",
+              "              'metadata': {'text': 'Which is the most populated city in the '\n",
+              "                                   'world.?'},\n",
+              "              'score': 0.8828482,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []},\n",
+              "             {'id': '371413',\n",
+              "              'metadata': {'text': 'What is the most populated city in the '\n",
+              "                                   'world?'},\n",
+              "              'score': 0.8788713,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []},\n",
+              "             {'id': '177352',\n",
+              "              'metadata': {'text': 'What are the most populated cities in the '\n",
+              "                                   'world?'},\n",
+              "              'score': 0.84194744,\n",
+              "              'sparse_values': {'indices': [], 'values': []},\n",
+              "              'values': []}],\n",
+              " 'namespace': ''}"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "query = \"which city has the highest population in the world?\"\n",
+        "\n",
+        "# create the query vector\n",
+        "xq = model.encode(query).tolist()\n",
+        "\n",
+        "# now query\n",
+        "xc = index.query(xq, top_k=3, include_metadata=True)\n",
+        "xc"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-XwOWcgo_QtI"
+      },
+      "source": [
+        "In the returned response `xc` we can see the most relevant questions to our particular query. We can reformat this response to be a little easier to read:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gy7isg_f-vWg",
+        "outputId": "e015290b-9351-4a36-e8db-4fb250fa504f"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "0.88: Which is the most populated city in the world.?\n",
+            "0.88: What is the most populated city in the world?\n",
+            "0.84: What are the most populated cities in the world?\n"
+          ]
+        }
+      ],
+      "source": [
+        "for result in xc['matches']:\n",
+        "    print(f\"{round(result['score'], 2)}: {result['metadata']['text']}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1JK5yApl_5fE"
+      },
+      "source": [
+        "These are clearly very relevant results. All of these questions either share the exact same meaning as our question, or are related. We can make this harder by using more complicated language, but as long as the \"meaning\" behind our query remains the same, we should see similar results."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dJbjE-iq_yMr",
+        "outputId": "7074297e-fed5-4242-fe91-6817c5303976"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "0.64: What are the most populated cities in the world?\n",
+            "0.62: Which is the most populated city in the world.?\n",
+            "0.62: What is the most populated city in the world?\n"
+          ]
+        }
+      ],
+      "source": [
+        "query = \"which urban locations have the highest concentration of homo sapiens?\"\n",
+        "\n",
+        "# create the query vector\n",
+        "xq = model.encode(query).tolist()\n",
+        "\n",
+        "# now query\n",
+        "xc = index.query(xq, top_k=3, include_metadata=True)\n",
+        "for result in xc['matches']:\n",
+        "    print(f\"{round(result['score'], 2)}: {result['metadata']['text']}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HIAxOPb-A2w_"
+      },
+      "source": [
+        "Here we used *very different* language with completely different terms in our query than that of the returned documents. We substituted **\"city\"** for **\"urban location\"** and **\"populated\"** for **\"concentration of homo sapiens\"**.\n",
+        "\n",
+        "Despite these very different terms and *lack* of term overlap between query and returned documents — we get highly relevant results — this is the power of *semantic search*.\n",
+        "\n",
+        "You can go ahead and ask more questions above. When you're done, delete the index to save resources:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "-cWdeKzhAtww"
+      },
+      "outputs": [],
+      "source": [
+        "pinecone.delete_index(index_name)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PMMJSu_DbRx0"
+      },
+      "source": [
+        "---"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "29f86af39ebc4c588402c560e0793962": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "6ba5e03b6ed74eaf98bcf2073e6475b0": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "6f6c54d7b46242e2a1241e3d722713d3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_880d7798b2c14ef6a19723f2e1b5cc12",
+            "max": 4199,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_6ba5e03b6ed74eaf98bcf2073e6475b0",
+            "value": 4199
+          }
+        },
+        "7f2c61243d0542ef8ea8ab6683f16697": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "880d7798b2c14ef6a19723f2e1b5cc12": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "88279982dc91433a9ca6ab566c66d165": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_a42ac37b6dae48549dec3028ce1c1556",
+              "IPY_MODEL_6f6c54d7b46242e2a1241e3d722713d3",
+              "IPY_MODEL_b1580f14f23b4f9499d914e9dc10b8c8"
+            ],
+            "layout": "IPY_MODEL_7f2c61243d0542ef8ea8ab6683f16697"
+          }
+        },
+        "a42ac37b6dae48549dec3028ce1c1556": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_dd760ee9cf9c4444beef229d64f906a2",
+            "placeholder": "​",
+            "style": "IPY_MODEL_cd296bc17dbb47248eea1ec2ab6d5ab6",
+            "value": "100%"
+          }
+        },
+        "b1580f14f23b4f9499d914e9dc10b8c8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_d2a1d064c0464b43bc85b3a00df00879",
+            "placeholder": "​",
+            "style": "IPY_MODEL_29f86af39ebc4c588402c560e0793962",
+            "value": " 4199/4199 [07:35&lt;00:00, 10.87it/s]"
+          }
+        },
+        "cd296bc17dbb47248eea1ec2ab6d5ab6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "d2a1d064c0464b43bc85b3a00df00879": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "dd760ee9cf9c4444beef229d64f906a2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
New semantic search examples. One shows the data preparation process (`semantic-search.ipynb`), the other allows users to skip this using `pinecone-datasets` (`semantic-search-fast.ipynb`).

I'd propose this approach of having two parallel notebooks for _"fast"_ and not fast to be the standard for those we'd like to speed up with `pinecone-datasets`.