### PR TITLE
error in parameter spelling: enviroment -> environment

### DIFF
--- a/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
+++ b/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
@@ -1163,7 +1163,7 @@
         "# find your environment next to the api key in pinecone console\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)\n",
+        "pinecone.init(api_key=api_key, environment=env)\n",
         "pinecone.whoami()"
       ]
     },


### PR DESCRIPTION
error in pinecone.init parameter name