### PR TITLE
Fix URL builder to avoid 404 errors and environment typo

### DIFF
--- a/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
+++ b/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
@@ -122,7 +122,7 @@
         "import html\n",
         "import re\n",
         "\n",
-        "domain = \"https://python.langchain.com/en/latest/\"\n",
+        "domain = \"https://python.langchain.com/\"\n",
         "domain_full = domain+\"en/latest/\"\n",
         "\n",
         "soup = BeautifulSoup(res.text, 'html.parser')\n",
@@ -1163,7 +1163,7 @@
         "# find your environment next to the api key in pinecone console\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)\n",
+        "pinecone.init(api_key=api_key, environment=env)\n",
         "pinecone.whoami()"
       ]
     },


### PR DESCRIPTION
## Problem

The URL builder for scrapping was throwing a lot of 404 because it was duplicating part of the path.
Also, there is a typo in the word environment when loading Pinecone.

## Solution

Micro changes, self-explanatory.

## Type of Change

Bug fix (non-breaking change which fixes an issue)
