### PR TITLE
Update Langchain Links in the ipython notebook

### DIFF
--- a/generation/langchain/handbook/03-langchain-conversational-memory.ipynb
+++ b/generation/langchain/handbook/03-langchain-conversational-memory.ipynb
@@ -1687,7 +1687,7 @@
         "id": "2900a385"
       },
       "source": [
-        "The way this works is quite similar to the `ConversationKnowledgeGraphMemory`, you can refer to the [docs](https://langchain.readthedocs.io/en/latest/modules/memory/examples/entity_summary_memory.html) if you want to see it in action. "
+        "The way this works is quite similar to the `ConversationKnowledgeGraphMemory`, you can refer to the [docs](https://python.langchain.com/en/latest/modules/memory/types/entity_summary_memory.html) if you want to see it in action. "
       ]
     },
     {


### PR DESCRIPTION
## Problem

Hey a link in this example wasn't working and redirecting to the respective page in langchain docs.

## Solution

Update the link to the correct working link.

## Type of Change


- [ ] None of the above: (Simply changed a link so that people following the tutorial don't get misdirected to faulty link)

