### PR TITLE
add pytorch dependency for bm25 generation notebook

### DIFF
--- a/pinecone/sparse/bm25/bm25-vector-generation.ipynb
+++ b/pinecone/sparse/bm25/bm25-vector-generation.ipynb
@@ -70,6 +70,8 @@
       "source": [
         "!pip install -qU \\\n",
         "    pinecone-text \\\n",
+        "    sentence-transformers \\\n",
+        "    torch \\\n",
         "    pandas==2.0.2 \\\n",
         "    datasets==2.12.0 \\\n",
         "    pyarrow"


### PR DESCRIPTION
## Problem

BM25 vector generation notebook lack installation of torch and sentence transformers

## Solution

Install sentence transformers and pytorch dependecies

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Running notebooks