### PR TITLE
Fix docs download link

### DIFF
--- a/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
+++ b/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs.ipynb
@@ -89,7 +89,7 @@
         }
       ],
       "source": [
-        "!wget -r -A.html -P rtdocs https://python.langchain.com/en/latest/"
+        "!wget -r -A.html -P rtdocs https://api.python.langchain.com/en/latest/"
       ]
     },
     {


### PR DESCRIPTION
Langchain docs download link in this notebook is broken. This link seems to work.
@miararoy , @jamescalam to make sure the link is capturing the docs that were meant to be loaded for this demo
