### PR TITLE
cleanup + limit vector count to < 100k

### DIFF
--- a/search/semantic-search/semantic-search.ipynb
+++ b/search/semantic-search/semantic-search.ipynb
@@ -108,7 +108,7 @@
       "source": [
         "from datasets import load_dataset\n",
         "\n",
-        "dataset = load_dataset('quora', split='train[240000:320000]')\n",
+        "dataset = load_dataset('quora', split='train[240000:290000]')\n",
         "dataset"
       ]
     },
@@ -371,13 +371,13 @@
         "import pinecone\n",
         "\n",
         "# get api key from app.pinecone.io\n",
-        "PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY') or 'PINECONE_API_KEY'\n",
+        "api_key = os.environ.get('PINECONE_API_KEY') or 'PINECONE_API_KEY'\n",
         "# find your environment next to the api key in pinecone console\n",
-        "PINECONE_ENV = os.environ.get('PINECONE_ENVIRONMENT') or 'PINECONE_ENVIRONMENT'\n",
+        "env = os.environ.get('PINECONE_ENVIRONMENT') or 'PINECONE_ENVIRONMENT'\n",
         "\n",
         "pinecone.init(\n",
-        "    api_key=PINECONE_API_KEY,\n",
-        "    environment=PINECONE_ENV\n",
+        "    api_key=api_key,\n",
+        "    environment=env\n",
         ")"
       ]
     },


### PR DESCRIPTION
- Fixes the semantic search notebook to limit the dataset size to < 100k
- Makes the code consistent w/ other notebooks in how we initialize pinecone
