### PR TITLE
fix typo in env argument

### DIFF
--- a/generation/generative-qa/openai-ml-qa/01-making-queries.ipynb
+++ b/generation/generative-qa/openai-ml-qa/01-making-queries.ipynb
@@ -1127,7 +1127,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.11.2"
+      "version": "3.10.7 (main, Sep 14 2022, 22:38:23) [Clang 14.0.0 (clang-1400.0.29.102)]"
     },
     "vscode": {
       "interpreter": {

--- a/generation/generative-qa/openai-ml-qa/01-making-queries.ipynb
+++ b/generation/generative-qa/openai-ml-qa/01-making-queries.ipynb
@@ -118,7 +118,7 @@
         "# find your environment in the console next to your api key\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)\n",
+        "pinecone.init(api_key=api_key, environment=env)\n",
         "pinecone.whoami()"
       ]
     },
@@ -1127,7 +1127,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.10.7 (main, Sep 14 2022, 22:38:23) [Clang 14.0.0 (clang-1400.0.29.102)]"
+      "version": "3.11.2"
     },
     "vscode": {
       "interpreter": {

--- a/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
+++ b/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
@@ -332,7 +332,7 @@
         "# find your environment next to the api key in pinecone console\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)\n",
+        "pinecone.init(api_key=api_key, environment=env)\n",
         "pinecone.whoami()"
       ]
     },
@@ -873,7 +873,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "ml",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -887,11 +887,11 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.6"
+      "version": "3.10.10"
     },
     "vscode": {
       "interpreter": {
-        "hash": "b8e7999f96e1b425e2d542f21b571f5a4be3e97158b0b46ea1b2500df63956ce"
+        "hash": "57376684f67c5d7b1589c855d7d0f1a1bdf8944ab1b903e711fdbf39434567bb"
       }
     },
     "widgets": {

--- a/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
+++ b/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
@@ -887,7 +887,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.10"
+      "version": "3.9.6"
     },
     "vscode": {
       "interpreter": {

--- a/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
+++ b/generation/generative-qa/openai/gen-qa-openai/gen-qa-openai-fast.ipynb
@@ -873,7 +873,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "ml",
       "language": "python",
       "name": "python3"
     },

--- a/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs-fast.ipynb
+++ b/generation/gpt4-retrieval-augmentation/gpt-4-langchain-docs-fast.ipynb
@@ -351,7 +351,7 @@
         "# find your environment next to the api key in pinecone console\n",
         "env = os.getenv(\"PINECONE_ENVIRONMENT\") or \"PINECONE_ENVIRONMENT\"\n",
         "\n",
-        "pinecone.init(api_key=api_key, enviroment=env)"
+        "pinecone.init(api_key=api_key, environment=env)"
       ]
     },
     {

--- a/search/semantic-search/sparse/splade/splade-quora.md
+++ b/search/semantic-search/sparse/splade/splade-quora.md
@@ -231,7 +231,7 @@ api_key = os.getenv("PINECONE_API_KEY") or "PINECONE_API_KEY"
 # find environment next to your API key in the Pinecone console
 env = os.getenv("PINECONE_ENVIRONMENT") or "PINECONE_ENVIRONMENT"
 
-pinecone.init(api_key=api_key, enviroment=env)
+pinecone.init(api_key=api_key, environment=env)
 pinecone.whoami()
 ```
 


### PR DESCRIPTION
## Problem

There is a typo in the `environment` parameter name in some of the notebooks. Thanks @yaakovs to point it out.

@jhamon note that having a default value in the environment parameter ("us-west1") can cause troubles, especially when the user have a typo in the parameter name + we don't throw error on unrecognized parameter. 
 
## Solution

Fix the typo

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Manually test with non-default environments