### PR TITLE
Add README.md to repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Pinecone Examples
+
+![Pinecone Logo](./learn/images/pinecone_logo_w_background.png)
+![Long term memory for Artificial Intelligence](./learn/images/long-term-memory-for-ai.jpeg)
+
+# What is this repo?
+
+This repository is a collection of sample applications and Jupyter Notebooks that you can run, download, study and modify in order to get hands-on with 
+Pinecone [vector databases](https://www.pinecone.io/learn/vector-database/) and common AI patterns, tools and algorithms.
+
+# Two kinds of examples 
+
+This repo contains: 
+
+1. Production ready examples in [`./docs`](./docs) that receive regular review and support from the Pinecone engineering team
+2. Examples optimized for learning and exploration of AI techniques in [`./learn`](./learn) and patterns for building different kinds of applications, created and maintained by the Pinecone Developer Advocacy team. 
+
+We appreciate your feedback and contributions. Please see our [contribution guide](./learn/README.md#collaboration) for information on how to contribute to this repo. 
+
+# Getting started 
+
+Please see our [Getting started guide](./learn/README.md#getting-started) in our learn section for detailed instructions and a walkthrough of setting up and running a Jupyter Notebook in Google Colab for experimentation. 
+
+## We love feedback! 
+
+As you work through these examples, if you encounter any problems or things that are confusing or don't work quite right, please [open a new issue :octocat:](https://github.com/pinecone-io/examples/issues/new).
+
+## Getting support and further reading 
+
+Visit our: 
+* [Documentation](https://docs.pinecone.io)
+* [Support forums](https://community.pinecone.io)
+
+## Collaboration
+
+We truly appreciate your contributions to help us improve and maintain this community resource!
+
+If you've got ideas for improvements, want to contribute a quick fix like correcting a typo, or patching an obvious bug, feel free to open a new issue or even a pull request. If you're considering a larger or more involved change to this repository, its organization or the functionality of 
+one of the examples, please first [open a new issue :octocat:](https://github.com/pinecone-io/examples/issues/new) and state your proposed changes so we discuss them together before you invest a ton of time or effort into making changes. Thanks for your understanding and collaboration. 


### PR DESCRIPTION
## Problem

Add a simple root README to greet users with a little eye candy and relevant links. 

## Solution

I mostly copied the same look and feel from `./learn` while linking off to the `./learn` README as made sense to me. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Rendered locally and spot checked with `gh markdown-preview`.
