### PR TITLE
Add an image link to the YouTube video walkthrough for Notebooks

### DIFF
--- a/learn/README.md
+++ b/learn/README.md
@@ -12,6 +12,12 @@ These examples are ideal for learning and expanding your knowledge of what's pos
 
 Each individual example notebook lives in its own directory. A notebook file ends in `.ipynb`, and each individual Notebook demonstrates a different AI technique or usage pattern. 
 
+# How to use Jupyter Notebooks to do AI tasks
+
+This video walks through how to load these Notebooks and get started with Google colab. It is intended as a complement to this getting started guide:
+
+[![How to use Jupyter Notebooks for Machine learning and AI tasks](https://img.youtube.com/vi/1Z8T36sZ9WI/0.jpg)](https://www.youtube.com/watch?v=1Z8T36sZ9WI)
+
 # Getting started 
 
 Running the examples in this repo requires two things, both of which are free: 


### PR DESCRIPTION

## Problem

Describe the purpose of this change. What problem is being solved and why?

We've got a new YouTube video that walks folks through the basics of loading and using Jupyter Notebooks. This pull request uses the YouTube image trick (loading the first frame of a video as an image) in order to create an image link to the video itself, since it's unfortunately impossible to embed the video itself within a GitHub README.

![jupyter-notebooks-video-readme-embed](https://github.com/pinecone-io/examples/assets/1769996/4849ab6f-d984-4289-af9c-a4ce96fd9174)

Here's [a direct link](https://github.com/zackproser/examples/blob/a262a4e85a350da66736fe98b611718fff1c1247/learn/README.md) to the rendered, updated README for ease of review.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

I validated this change locally with `gh markdown-preview` and on my GitHub branch as well. It rendered correctly and linked to the correct video. 