### PR TITLE
fix pip dependency command

### DIFF
--- a/learn/generation/canopy/00-canopy-data-prep.ipynb
+++ b/learn/generation/canopy/00-canopy-data-prep.ipynb
@@ -15,8 +15,9 @@
    "outputs": [],
    "source": [
     "!pip install -qU \\\n",
-    "    canopy-sdk==0.1.0 \\\n",
-    "    datasets==2.14.6"
+    "    canopy-sdk \\\n",
+    "    datasets==2.14.6\\\n",
+    "    python-multipart"
    ]
   },
   {


### PR DESCRIPTION
## Problem

Pip installation command fails (https://github.com/pinecone-io/examples/issues/296)

## Solution

Removed invalid version number for `canopy-sdk` and added `python-multipart` (based on updated error output)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

- run new pip installation command in Colab notebook
