### PR TITLE
Remove markdown table of deprecated OpenAI models

### DIFF
--- a/learn/generation/langchain/handbook/xx-langchain-chunking.ipynb
+++ b/learn/generation/langchain/handbook/xx-langchain-chunking.ipynb
@@ -185,16 +185,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that for the tokenizer we defined the encoder as `\"cl100k_base\"`. This is a specific tiktoken encoder which is used by `gpt-3.5-turbo`. Other encoders exist. At the time of writing the OpenAI specific tokenizers (using `tiktoken`) are summarized as:\n",
-    "\n",
-    "| Encoder | Models |\n",
-    "| --- | --- |\n",
-    "| `cl100k_base` | `gpt-4`, `gpt-3.5-turbo`, `text-embedding-ada-002` |\n",
-    "| `p50k_base` | `text-davinci-003`, `code-davinci-002`, `code-cushman-002` |\n",
-    "| `r50k_base` | `text-davinci-001`, `davinci`, `text-similarity-davinci-001` |\n",
-    "| `gpt2` | `gpt2` |\n",
-    "\n",
-    "You can find these details in the [Tiktoken `model.py` script](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py), or using `tiktoken.encoding_for_model`:"
+     "Note that for the tokenizer we defined the encoder as `\"cl100k_base\"`. This is a specific tiktoken encoder which is used by `gpt-3.5-turbo`, as well as `gpt-4`, and `text-embedding-ada-002` which are models supported by OpenAI at the time of this writing. Other encoders may be available, but are used with models that are now deprecated by OpenAI.\n",
+                "\n",
+     "You can find more details in the [Tiktoken `model.py` script](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py), or using `tiktoken.encoding_for_model`:"
    ]
   },
   {


### PR DESCRIPTION
## Problem

OpenAI is deprecating several legacy models on January 4th, 2024, which we are still referencing in this Notebook.

## Solution

Remove the markdown table referencing deprecated OpenAI models. Update info to reflect which models remain supported currently.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

This was verified via the Preview interface on GitHub
