### PR TITLE
docs: fix 06-langchain-agents.ipynb

### DIFF
--- a/learn/generation/langchain/handbook/06-langchain-agents.ipynb
+++ b/learn/generation/langchain/handbook/06-langchain-agents.ipynb
@@ -428,9 +428,9 @@
     {
       "cell_type": "markdown",
       "source": [
-        "In this first example we will use slightly different type of agent - SQL Agent which can be instantiated with it's own method `create_sql_agent`. Other agents will be instantiated in more generic way as we will see below in other examples.\n",
+        "In this first example we will use a slightly different type of agent - SQL Agent which can be instantiated with its own method `create_sql_agent`. Other agents will be instantiated more generically as we will see below in other examples.\n",
         "<br><br>\n",
-        "This method uses *toolkit* instead of simple list of `tools`. You can read more about them in the [documentation](https://python.langchain.com/docs/modules/agents/toolkits/). For this use case, we will use `SQLDatabaseToolkit`."
+        "This method uses *toolkit* instead of a simple list of `tools`. You can read more about them in the [documentation](https://python.langchain.com/docs/modules/agents/toolkits/). For this use case, we will use `SQLDatabaseToolkit`."
       ],
       "metadata": {
         "id": "Tgn6dRLEcxli"

--- a/learn/generation/langchain/handbook/06-langchain-agents.ipynb
+++ b/learn/generation/langchain/handbook/06-langchain-agents.ipynb
@@ -377,7 +377,7 @@
         "from langchain_experimental.sql import SQLDatabaseChain\n",
         "\n",
         "db = SQLDatabase(engine)\n",
-        "sql_chain = SQLDatabaseChain(llm=llm, database=db, verbose=True)"
+        "sql_chain = SQLDatabaseChain.from_llm(llm=llm, db=db, verbose=True)"
       ]
     },
     {


### PR DESCRIPTION
## Problem

fixing user warning
```
Directly instantiating an SQLDatabaseChain with an llm is deprecated. Please instantiate with llm_chain argument or using the from_llm class method.
```

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)