### PR TITLE
Langchain retrieval agents colab: Fix link to full example

### DIFF
--- a/docs/langchain-retrieval-agent.ipynb
+++ b/docs/langchain-retrieval-agent.ipynb
@@ -29,7 +29,7 @@
         "\n",
         "Merging these methods gives us the best of both worlds. In this notebook we'll learn how to do this.\n",
         "\n",
-        "[![Open full notebook](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/full-link.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/generation/langchain/handbook/08-langchain-retrieval-agent.ipynb)\n",
+        "[![Open full notebook](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/full-link.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/08-langchain-retrieval-agent.ipynb)\n",
         "\n",
         "To begin, we must install the prerequisite libraries that we will be using in this notebook."
       ]
@@ -72,7 +72,7 @@
         "id": "qNyRsz0ZXXaq"
       },
       "source": [
-        "We will download a pre-embedded dataset from `pinecone-datasets`. Allowing us to skip the embedding and preprocessing steps, if you'd rather work through those steps you can find the [full notebook here](https://github.com/pinecone-io/examples/blob/master/generation/langchain/handbook/08-langchain-retrieval-agent.ipynb)."
+        "We will download a pre-embedded dataset from `pinecone-datasets`. Allowing us to skip the embedding and preprocessing steps, if you'd rather work through those steps you can find the [full notebook here](https://colab.research.google.com/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/08-langchain-retrieval-agent.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
The previous link was broken, probably because the target notebook moved at some point.

