### PR TITLE
Update interacting-with-the-index.ipynb

### DIFF
--- a/docs/quick-tour/interacting-with-the-index.ipynb
+++ b/docs/quick-tour/interacting-with-the-index.ipynb
@@ -824,7 +824,7 @@
       ],
       "source": [
         "# Update vectors by ID\n",
-        "index.upsert(vectors=[(\"A\",[0., 0.])])"
+        "index.upsert(vectors=[(\"A\",[0.1, 0.1])])"
       ]
     },
     {


### PR DESCRIPTION
## Problem

new error specific to serverless due to all 0 vectors causing index building issues.  We should update the notebooks if they use all 0 vectors

## Solution

change vectors to be non all zero

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
