### PR TITLE
fix import statements for legacy client

### DIFF
--- a/learn/generation/rag-for-hybrid/rag-for-hybrid-search.ipynb
+++ b/learn/generation/rag-for-hybrid/rag-for-hybrid-search.ipynb
@@ -185,7 +185,7 @@
     }
    ],
    "source": [
-    "from pinecone import Pinecone\n",
+    "import pinecone\n",
     "import os\n",
     "import re\n",
     "from uuid import uuid4\n",
@@ -198,7 +198,6 @@
     "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
     "from langchain.docstore.document import Document\n",
     "from sentence_transformers import SentenceTransformer\n",
-    "from pinecone import Pinecone\n",
     "import openai\n",
     "from pinecone.core.client.model.query_response import QueryResponse\n",
     "\n",


### PR DESCRIPTION
## Problem

running `from pinecone import Pinecone` gives the error `ImportError: cannot import name 'Pinecone' from 'pinecone'

## Solution

Updated import statement to reflect legacy client (2.2.4)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested in Colab