### PR TITLE
fix: update broken image links

### DIFF
--- a/learn/search/image/image-retrieval-ebook/clip-object-detection/zero-shot-object-detection-clip.ipynb
+++ b/learn/search/image/image-retrieval-ebook/clip-object-detection/zero-shot-object-detection-clip.ipynb
@@ -330,7 +330,7 @@
    "source": [
     "The first step is done. We are now almost ready to process those patches using CLIP. Before doing it, we might want to work through these patches by grouping them into a 6x6 window.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/image-retrieval/clip-object-detection/assets/window.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> "
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/search/image/image-retrieval-ebook/clip-object-detection/assets/window.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> "
    ]
   },
   {
@@ -1153,7 +1153,7 @@
     "The first column represents non-zero row positions, while the second column non-zero column positions. We can visualize the above co-ordinates as follows:\n",
     "\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/image-retrieval/clip-object-detection/assets/detection-coordinates.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/search/image/image-retrieval-ebook/clip-object-detection/assets/detection-coordinates.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
     "<center><small>Co-ordinates of patches with similarity score > 0.5.</small></center>"
    ]
   },
@@ -1162,7 +1162,7 @@
    "metadata": {},
    "source": [
     "The bounding box we want to design, will be around the area of interest.\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/image-retrieval/clip-object-detection/assets/bounding-box.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/search/image/image-retrieval-ebook/clip-object-detection/assets/bounding-box.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
     "<center><small>Bounding box.</small></center>"
    ]
   },
@@ -1172,7 +1172,7 @@
    "source": [
     "We can build it by calculating its corners, which correspond to the minimum and maximum $x$ and $y$ co-ordinates, i.e., $(x_{min}, y_{min})$, $(x_{max}, y_{min})$, $(x_{min}, y_{max})$, and $(x_{max}, y_{max})$.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/image-retrieval/clip-object-detection/assets/bounding-coordinates.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/search/image/image-retrieval-ebook/clip-object-detection/assets/bounding-coordinates.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
     "<center><small>Bounding box corners' co-ordinates.</small></center>"
    ]
   },
@@ -1261,7 +1261,7 @@
    "source": [
     "We use `(y_max - y_min)` and `(x_max - x_min)` to calculate the height and width of the bounding box respectively...\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/image-retrieval/clip-object-detection/assets/box-height-width.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/search/image/image-retrieval-ebook/clip-object-detection/assets/box-height-width.png\" alt=\"Drawing\" style=\"width:300px;\"/></div> </center> \n",
     "<center><small>Height and width calculations.</small></center>\n"
    ]
   },


### PR DESCRIPTION
## Problem

https://github.com/pinecone-io/examples/pull/246 broke image links in [image retrieval](https://github.com/pinecone-io/examples/tree/master/learn/search/image/image-retrieval-ebook) e-books.

## Solution

Update broken image links with correct ones.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested in Colab.
