### PR TITLE
Fix: Update link to point to `splade-quora.ipynb`

### DIFF
--- a/learn/search/semantic-search/sparse/splade/splade-vector-generation.ipynb
+++ b/learn/search/semantic-search/sparse/splade/splade-vector-generation.ipynb
@@ -1002,7 +1002,7 @@
       "source": [
         "And now we have all we need to start using Pinecone vector database 🚀\n",
         "\n",
-        "For more details on that, check out [this notebook](https://github.com/pinecone-io/examples/blob/master/pinecone/sparse/splade/splade-quora.ipynb)."
+        "For more details on that, check out [this notebook](https://github.com/pinecone-io/examples/blob/master/learn/search/semantic-search/sparse/splade/splade-quora.ipynb)."
       ]
     }
   ],


### PR DESCRIPTION
## Problem

In the notebook `splade-vector-generation.ipynb`, there's a link to another notebook, `splade-quora.ipynb`. This link currently 404s.

## Solution

 This PR updates the link to point to the correct location of the `splade-quora.ipynb` notebook.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
