### PR TITLE
Bump pinecone-plugin-assistant to 0.1.3

### DIFF
--- a/learn/generation/pinecone-assistant/assistants-ai-demo.ipynb
+++ b/learn/generation/pinecone-assistant/assistants-ai-demo.ipynb
@@ -26,7 +26,7 @@
       "source": [
         "!pip install -qU \\\n",
         "    pinecone-client==\"4.1.1\" \\\n",
-        "    pinecone-plugin-assistant==\"0.1.2\" \\\n",
+        "    pinecone-plugin-assistant==\"0.1.3\" \\\n",
         "    pinecone-notebooks==\"0.1.1\""
       ]
     },


### PR DESCRIPTION
## Problem

There's a bug in earlier versions of the `pinecone-plugin-assistant` library that incorrectly throws errors, suggesting the user's Pinecone API key is invalid.

## Solution

Update the `pinecone-plugin-assistant` to `0.1.3`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

We've validated this fix via Google Colab.
