### PR TITLE
Add colab and nbviewer widgets to reranker notebook

### DIFF
--- a/docs/pinecone_reranker.ipynb
+++ b/docs/pinecone_reranker.ipynb
@@ -7,8 +7,9 @@
         "id": "EE8es7PuO2RM"
       },
       "source": [
-        "# Pinecone Serverless Reranking in Action\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/docs/pinecone-reranker.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/pinecone-io/examples/blob/master/docs/pinecone-reranker.ipynb)\n",
         "\n",
+        "# Pinecone Serverless Reranking in Action\n",
         "\n",
         "### Overview\n",
         "\n",


### PR DESCRIPTION
## Problem

Reranker notebook is missing the colab and nbviewer widgets.

## Solution

Add them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
