### PR TITLE
Update gpt model to 4o-mini in gen-qa-openai.ipynb

### DIFF
--- a/docs/gen-qa-openai.ipynb
+++ b/docs/gen-qa-openai.ipynb
@@ -850,7 +850,7 @@
         "    sys_prompt = \"You are a helpful assistant that always answers questions.\"\n",
         "    # query text-davinci-003\n",
         "    res = openai.ChatCompletion.create(\n",
-        "        model='gpt-3.5-turbo-0613',\n",
+        "        model='gpt-4o-mini-2024-07-18',\n",
         "        messages=[\n",
         "            {\"role\": \"system\", \"content\": sys_prompt},\n",
         "            {\"role\": \"user\", \"content\": prompt}\n",


### PR DESCRIPTION
## Problem

The current model in the notebook `gpt-3.5-turbo-0613` is deprecated, so the notebook does not run. 

## Solution

OpenAI [suggests switching to GPT-4o mini](https://platform.openai.com/docs/models/gpt-3-5-turbo), so I swapped to that and pinned it to a specific version (`gpt-4o-mini-2024-07-18`) for consistency. We can also use `gpt-4o-mini` which will automatically update versions. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

I ran the notebook using the [internal workflow](https://github.com/pinecone-io/pinecone-db/actions/runs/10951860458), and it passed.
