### PR TITLE
Rename index in import notebook

### DIFF
--- a/docs/pinecone-bulk-import.ipynb
+++ b/docs/pinecone-bulk-import.ipynb
@@ -1330,7 +1330,7 @@
         "# Define serverless specifications\n",
         "spec = ServerlessSpec(cloud=cloud, region=region)\n",
         "\n",
-        "index_name = \"pinecone-bulk-import1-1024-1\"\n",
+        "index_name = \"pinecone-import1-1024-1\"\n",
         "dimension = 1024\n",
         "\n",
         "# List all existing indexes\n",


### PR DESCRIPTION
## Problem / Solution

We're not using the term "bulk import" anymore, so this PR renames the index from `pinecone-bulk-import1-1024-1` to `pinecone-import1-1024-1`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
