### PR TITLE
fix: update broken `nbviewer` path to the notebook

### DIFF
--- a/learn/generation/langchain/handbook/10-langchain-multi-query.ipynb
+++ b/learn/generation/langchain/handbook/10-langchain-multi-query.ipynb
@@ -5,7 +5,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/10-langchain-multi-query.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/08-langchain-multi-query.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/10-langchain-multi-query.ipynb) [![Open nbviewer](https://raw.githubusercontent.com/pinecone-io/examples/master/assets/nbviewer-shield.svg)](https://nbviewer.org/github/pinecone-io/examples/blob/master/learn/generation/langchain/handbook/10-langchain-multi-query.ipynb)"
       ]
     },
     {


### PR DESCRIPTION
## Problem

The lesson **"LangChain Multi-Query for RAG"** has the wrong link to `nbviewer`. 

![{DF2B4586-584D-4AE4-A413-D6E71E9CE785}](https://github.com/user-attachments/assets/e9d5ce2b-9cb5-4dc1-b84d-e6c3918b2047)

## Solution

The broken link should be changed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

One can change the last part of the broken nbviewer link from<br>`08-langchain-multi-query.ipynb` to `10-langchain-multi-query.ipynb`.
