### PR TITLE
Updated hello-pinecone-aws example to use pinecone-client==6.0.1

### DIFF
--- a/learn/search/semantic-search/hello-pinecone-aws.ipynb
+++ b/learn/search/semantic-search/hello-pinecone-aws.ipynb
@@ -94,7 +94,7 @@
       "outputs": [],
       "source": [
         "!pip install -qU \\\n",
-        "  pinecone-client==6.0.1 \\\n",
+        "  pinecone==6.0.1 \\\n",
         "  pandas==2.2.3"
       ]
     },

--- a/learn/search/semantic-search/hello-pinecone-aws.ipynb
+++ b/learn/search/semantic-search/hello-pinecone-aws.ipynb
@@ -94,8 +94,8 @@
       "outputs": [],
       "source": [
         "!pip install -qU \\\n",
-        "  pinecone-client==3.1.0 \\\n",
-        "  pandas==2.0.3"
+        "  pinecone-client==6.0.1 \\\n",
+        "  pandas==2.2.3"
       ]
     },
     {
@@ -110,19 +110,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "3f0a5ee4",
+      "execution_count": 3,
+      "id": "8e0eb752",
       "metadata": {},
       "outputs": [],
       "source": [
         "import os\n",
+        "from getpass import getpass\n",
+        "\n",
+        "os.environ[\"PINECONE_API_KEY\"] = os.getenv(\"PINECONE_API_KEY\") or \\\n",
+        "    getpass(\"Enter Pinecone API Key: \")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "id": "3f0a5ee4",
+      "metadata": {},
+      "outputs": [],
+      "source": [
         "from pinecone import Pinecone\n",
         "\n",
-        "# initialize connection to pinecone (get API key at app.pinecone.io)\n",
-        "api_key = os.environ.get('PINECONE_API_KEY') or 'PINECONE_API_KEY'\n",
-        "\n",
         "# configure client\n",
-        "pc = Pinecone(api_key=api_key)"
+        "pc = Pinecone()"
       ]
     },
     {
@@ -148,7 +158,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 24,
       "id": "EA2EcZsCoWS3",
       "metadata": {
         "id": "EA2EcZsCoWS3",
@@ -164,17 +174,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 25,
       "id": "774014f4",
       "metadata": {},
       "outputs": [
         {
           "data": {
             "text/plain": [
-              "[]"
+              "['hybrid-test', 'index', 'rerankers']"
             ]
           },
-          "execution_count": 3,
+          "execution_count": 25,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -185,7 +195,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 26,
       "id": "synthetic-essex",
       "metadata": {
         "execution": {
@@ -221,7 +231,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 27,
       "id": "8ebeab38",
       "metadata": {},
       "outputs": [],
@@ -255,7 +265,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 28,
       "id": "4YwC8livCrn2",
       "metadata": {
         "execution": {
@@ -282,7 +292,8 @@
         "pc.create_index(\n",
         "    name=index_name,\n",
         "    dimension=dimensions,\n",
-        "    metric=\"cosine\"\n",
+        "    metric=\"cosine\",\n",
+        "    spec=spec\n",
         ")\n",
         "\n",
         "# wait for index to be ready before connecting\n",
@@ -292,7 +303,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 29,
       "id": "toy-VhU4LO_O",
       "metadata": {
         "execution": {
@@ -313,7 +324,7 @@
       },
       "outputs": [],
       "source": [
-        "index = pc.Index(index_name=index_name)"
+        "index = pc.Index(name=index_name)"
       ]
     },
     {
@@ -337,7 +348,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 30,
       "id": "indirect-lafayette",
       "metadata": {
         "colab": {
@@ -408,7 +419,7 @@
               "1  B  [1.0, 2.0, 3.0]"
             ]
           },
-          "execution_count": 7,
+          "execution_count": 30,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -445,7 +456,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 31,
       "id": "efficient-parliament",
       "metadata": {
         "colab": {
@@ -475,7 +486,7 @@
               "{'upserted_count': 2}"
             ]
           },
-          "execution_count": 8,
+          "execution_count": 31,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -486,7 +497,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 32,
       "id": "enclosed-performer",
       "metadata": {
         "colab": {
@@ -515,11 +526,13 @@
             "text/plain": [
               "{'dimension': 3,\n",
               " 'index_fullness': 0.0,\n",
-              " 'namespaces': {'': {'vector_count': 2}},\n",
-              " 'total_vector_count': 2}"
+              " 'metric': 'cosine',\n",
+              " 'namespaces': {},\n",
+              " 'total_vector_count': 0,\n",
+              " 'vector_type': 'dense'}"
             ]
           },
-          "execution_count": 9,
+          "execution_count": 32,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -530,7 +543,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 35,
       "id": "leading-shape",
       "metadata": {
         "colab": {
@@ -558,10 +571,11 @@
           "data": {
             "text/plain": [
               "{'matches': [{'id': 'A', 'score': 1.0, 'values': [1.0, 1.0, 1.0]}],\n",
-              " 'namespace': ''}"
+              " 'namespace': '',\n",
+              " 'usage': {'read_units': 6}}"
             ]
           },
-          "execution_count": 11,
+          "execution_count": 35,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -596,7 +610,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 36,
       "id": "indian-broadcast",
       "metadata": {
         "execution": {
@@ -617,7 +631,7 @@
       },
       "outputs": [],
       "source": [
-        "pc.delete_index(index_name)"
+        "pc.delete_index(name=index_name)"
       ]
     },
     {
@@ -635,7 +649,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -649,7 +663,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.12"
+      "version": "3.12.7"
     },
     "papermill": {
       "default_parameters": {},

--- a/learn/search/semantic-search/hello-pinecone-aws.ipynb
+++ b/learn/search/semantic-search/hello-pinecone-aws.ipynb
@@ -95,7 +95,7 @@
       "source": [
         "!pip install -qU \\\n",
         "  pinecone==6.0.1 \\\n",
-        "  pandas==2.2.3"
+        "  pandas==2.2.2"
       ]
     },
     {


### PR DESCRIPTION
## Problem

The current notebook `hello-pinecone-aws.ipynb` uses pinecone-client==3.0.5 which is outdated and therefore some functions needed updating alongside the notebook.

## Solution

Updated the notebook to use pinecone-client==6.0.1 and amended functions to use up-to-date parameters, such as:
- Renaming the `index_name` parameter to `name` in the `Index` method.
- Adding a `spec` parameter to the `create_index` method.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc) - Just updating an example notebook
- [ ] None of the above: (explain here) 

## Test Plan

A quick run through the notebook to check it runs as intended.
