### PR TITLE
Fix broken image links in offline-evaluation notebook

### DIFF
--- a/learn/experimental/algos-and-libraries/offline-evaluation/offline-evaluation.ipynb
+++ b/learn/experimental/algos-and-libraries/offline-evaluation/offline-evaluation.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "In this notebook, we go through the most common offline metrics. These can be divided again into order-unaware (e.g., Recall@k and Precision@k) and order-aware metrics (e.g., MRR, MAP, and NDCG@k).\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/metrics_diagram.png\" alt=\"Drawing\" style=\"width:400px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/metrics_diagram.png\" alt=\"Drawing\" style=\"width:600px;\"/></div> </center>"
    ]
   },
   {
@@ -40,7 +40,7 @@
     "\n",
     "Suppose that we have a small eight-image dataset (in reality this number is more likely to be in the million+ range) and searches for *\"cat in the box\"*. The retrieval engine returns all $k = 8$ results. These can be represented by the following images:\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>\n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>\n",
     "\n",
     "From the above, $4$ out of $8$ results are relevant, we call them *actual relevant results* as they show a cat inside a box (see results $\\#2$, $\\#4$, $\\#5$, and $\\#7$). \n",
     "\n",
@@ -48,7 +48,7 @@
     "\n",
     "We have highlighted in cyan these actual relevant results.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example_highlighted.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>\n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example_highlighted.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>\n",
     "\n",
     "It is this dataset that we will use throughout this notebook. We will learn how to use offline metrics and define them in *Python*."
    ]
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/confusion_matrix.png\" alt=\"Drawing\" style=\"width: 400px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/confusion_matrix.png\" alt=\"Drawing\" style=\"width: 400px;\"/></div> </center>"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "source": [
     "Let's clarify this by looking at our example of cat in the box. Suppose that the software predicts as *positive* the first $2$ results. In this case, we will have $1$ true positive, $3$ true negative, $1$ false positive, and $3$ false negative.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example_condition.png\" alt=\"Drawing\" style=\"width: 500px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example_condition.png\" alt=\"Drawing\" style=\"width: 500px;\"/></div> </center>"
    ]
   },
   {
@@ -124,7 +124,7 @@
     "\n",
     "Let's go back to our example with $N = 8$, $K = 1...N$, and $4$ actual relevant results - see them below in cyan.\n",
     " \n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example_highlighted.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example_highlighted.png\" alt=\"Drawing\" style=\"width:550px;\"/></div> </center>"
    ]
   },
   {
@@ -137,7 +137,7 @@
     "\n",
     "$$Recall@2 = \\frac{1}{1 + 3} = \\frac{1}{4} = 0.25$$\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/recall-at-two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/recall-at-two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
    ]
   },
   {
@@ -258,7 +258,7 @@
     "\n",
     "The other queries can be *\"white cat\"* and *\"dark cat\"*. The search results are shown below, where the cyan highlighted images correspond to the actual relevant results based on the query.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/mrr.png\" alt=\"Drawing\" style=\"width: 900px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/mrr.png\" alt=\"Drawing\" style=\"width: 900px;\"/></div> </center>"
    ]
   },
   {
@@ -377,7 +377,7 @@
     "\n",
     "$$Precision@2 = \\frac{1}{1 + 1} = \\frac{1}{2} = 0.50$$\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/precision-at-two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/precision-at-two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
    ]
   },
   {
@@ -423,7 +423,7 @@
     "\n",
     "Following what previously explained, $Precision@k$ and $rel_k$ will be the following:\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example_MAP.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example_MAP.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
    ]
   },
   {
@@ -432,7 +432,7 @@
    "source": [
     "Given that $Precision@k$ is multiplied by $rel_k$, the formula can be simplified when $rel_k = 0$ as $Precision@k * rel_k = 0$.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/example_MAP2.png\" alt=\"Drawing\" style=\"width: 250px;\"/></div> </center>\n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/example_MAP2.png\" alt=\"Drawing\" style=\"width: 250px;\"/></div> </center>\n",
     "\n",
     "We then need to calculate $\\sum_{k = 1}^{n} (Precision@k * rel_k)$ for each query, and divide it by the *# of relevant results* to get the $AP@K_q$ score. The # of relevant results will be $4$ for query $\\#1$, $4$ for query $\\#2$, and $2$ for query $\\#3$."
    ]
@@ -543,7 +543,7 @@
    "source": [
     "The $CG@K$ metric is calculated as the sum of the top-$K$ relevance scores. Differently from before, the results from the user's search will not be divided into relevant and not relevant but will be rated from the less to the most relevant. We can use different colors to characterize the different scores: dark grey will be the color associated to the less relevant result $(0)$, cyan will be the color associated to the most relevant result $(4)$.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/relevance_score.png\" alt=\"Drawing\" style=\"width: 400px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/relevance_score.png\" alt=\"Drawing\" style=\"width: 400px;\"/></div> </center>"
    ]
   },
   {
@@ -552,7 +552,7 @@
    "source": [
     "Let's now consider another example with $1$ query (this time, the user will search for *\"***white*** cat in the box\"*), $K = 8$, $k = 1...K$, and let's include the relevance score. Based on judgement, and considering their position, $k$, the relevance score can be assigned as follows:\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/ndcg_relevance.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>\n",
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/ndcg_relevance.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>\n",
     "\n",
     "We can then calculate the cumulative gain *up to* position $K$, or $CG@K$, by summing up the relevance scores up to $K$."
    ]
@@ -595,7 +595,7 @@
    "source": [
     "It's worth noting how this metric does not consider the position of the results. For example, if we swap the first two results so that the relevance for $k = 1$ equals $4$ and the relevance for $k = 2$ equals $0$, we can see that $CG@2$ is still $4$, even though having relevance $4$ as first result is often better than having it as the second.\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/ndcg_relevance_two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/ndcg_relevance_two.png\" alt=\"Drawing\" style=\"width: 450px;\"/></div> </center>"
    ]
   },
   {
@@ -684,7 +684,7 @@
     "\n",
     "If we consider our example, ideally, we would have wanted our results to be sorted by relevance, as follows:\n",
     "\n",
-    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/algos-and-libraries/offline-evaluation/assets/ndcg_relevance_sorted.png\" alt=\"Drawing\" style=\"width: 500px;\"/></div> </center>"
+    "<center><div> <img src=\"https://raw.githubusercontent.com/pinecone-io/examples/master/learn/experimental/algos-and-libraries/offline-evaluation/assets/ndcg_relevance_sorted.png\" alt=\"Drawing\" style=\"width: 500px;\"/></div> </center>"
    ]
   },
   {


### PR DESCRIPTION
## Problem

It appears that links got broken when this algos-and-libraries directory got moved without updating image links inside the notebooks

## Solution

Adjust paths

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
