### PR TITLE
Update SDK version in quickstart notebook

### DIFF
--- a/docs/pinecone-quickstart.ipynb
+++ b/docs/pinecone-quickstart.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "!pip install -qU \\\n",
-    "    pinecone==6.0.2 \\\n",
+    "    pinecone==7.0.1 \\\n",
     "    pinecone-notebooks"
    ]
   },


### PR DESCRIPTION
## Problem

The quickstart notebook doesn't use the latest major SDK version.

## Solution

Update the pip install command.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210359445944091