### PR TITLE
Skip template strings when verifying links

### DIFF
--- a/.github/actions/check-links/check-links.py
+++ b/.github/actions/check-links/check-links.py
@@ -58,6 +58,9 @@ with open(nb_source_path, "r", encoding="utf-8") as f:
                 if any(ignore_link in link for ignore_link in ignore_links):
                     print(f"  ⏭️ {link}")
                     continue
+                if "{" in link: # template strings don't need to be checked
+                    print(f"  ⏭️ {link}")
+                    continue
                 if link in known_good_links:
                     good_links.add(link)
                     print(f"  ✅ {link}")


### PR DESCRIPTION
## Problem

We don't want the link checker to fail when trying to verify links like `https://reddit.com/r/{x['subreddit']}/comments/{x['id']}`

## Solution

Skip links that contain `{`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
