### PR TITLE
Added delay after upsert and delete for eventual consistency

### DIFF
--- a/docs/quick-tour/interacting-with-the-index.ipynb
+++ b/docs/quick-tour/interacting-with-the-index.ipynb
@@ -106,7 +106,17 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install -qU pandas==2.2.3 pinecone==6.0.2"
    ]
@@ -143,7 +153,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/Users/aarshitaacharya/.pyenv/versions/3.10.16/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
@@ -245,7 +255,7 @@
        "{\n",
        "    \"name\": \"interacting-with-the-index\",\n",
        "    \"metric\": \"euclidean\",\n",
-       "    \"host\": \"interacting-with-the-index-dojoi3u.svc.aped-4627-b74a.pinecone.io\",\n",
+       "    \"host\": \"interacting-with-the-index-dxs2y97.svc.aped-4627-b74a.pinecone.io\",\n",
        "    \"spec\": {\n",
        "        \"serverless\": {\n",
        "            \"cloud\": \"aws\",\n",
@@ -297,7 +307,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The index host is interacting-with-the-index-dojoi3u.svc.aped-4627-b74a.pinecone.io\n"
+      "The index host is interacting-with-the-index-dxs2y97.svc.aped-4627-b74a.pinecone.io\n"
      ]
     }
    ],
@@ -319,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "d686f6a8-5536-4890-a0ca-653a3b62e666",
    "metadata": {},
    "outputs": [],
@@ -351,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "analyzed-charity",
    "metadata": {
     "colab": {
@@ -434,7 +444,7 @@
        "4  E  [5.0, 5.0]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -470,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "checked-christopher",
    "metadata": {
     "colab": {
@@ -494,7 +504,7 @@
        "{'upserted_count': 5}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -502,6 +512,23 @@
    "source": [
     "# Upsert the vectors\n",
     "index.upsert(vectors=zip(df.id, df.vector))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2940b354",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "\n",
+    "def is_fresh(index):\n",
+    "    stats = index.describe_index_stats()\n",
+    "    vector_count = stats.total_vector_count\n",
+    "    print(f\"Vector count: \", vector_count)\n",
+    "    return vector_count > 0"
    ]
   },
   {
@@ -525,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "varied-scene",
    "metadata": {
     "colab": {
@@ -544,18 +571,32 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vector count:  0\n",
+      "Vector count:  0\n",
+      "Vector count:  0\n",
+      "Vector count:  5\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
        "FetchResponse(namespace='', vectors={'A': Vector(id='A', values=[1.0, 1.0], metadata=None, sparse_values=None), 'B': Vector(id='B', values=[2.0, 2.0], metadata=None, sparse_values=None)}, usage={'read_units': 1})"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Fetch vectors by ID\n",
+    "while not is_fresh(index):\n",
+    "    # It takes a few moments for vectors we just upserted\n",
+    "    # to become available for querying\n",
+    "    time.sleep(5)\n",
+    "\n",
     "fetch_results = index.fetch(ids=[\"A\", \"B\"])\n",
     "fetch_results"
    ]
@@ -581,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "id": "dried-demographic",
    "metadata": {
     "colab": {
@@ -602,10 +643,13 @@
     {
      "data": {
       "text/plain": [
-       "{'matches': [], 'namespace': '', 'usage': {'read_units': 1}}"
+       "{'matches': [{'id': 'A', 'score': 0.0199999809, 'values': []},\n",
+       "             {'id': 'B', 'score': 1.61999989, 'values': []}],\n",
+       " 'namespace': '',\n",
+       " 'usage': {'read_units': 1}}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -637,7 +681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "id": "generic-witness",
    "metadata": {
     "colab": {
@@ -661,7 +705,7 @@
        "FetchResponse(namespace='', vectors={'A': Vector(id='A', values=[1.0, 1.0], metadata=None, sparse_values=None)}, usage={'read_units': 1})"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -674,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "id": "comic-rwanda",
    "metadata": {
     "colab": {
@@ -698,7 +742,7 @@
        "{'upserted_count': 1}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -710,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 15,
    "id": "gentle-messenger",
    "metadata": {
     "colab": {
@@ -734,13 +778,15 @@
        "FetchResponse(namespace='', vectors={'A': Vector(id='A', values=[0.1, 0.1], metadata=None, sparse_values=None)}, usage={'read_units': 1})"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Fetch vector by the same ID again\n",
+    "\n",
+    "time.sleep(5)\n",
     "fetch_result = index.fetch(ids=[\"A\"])\n",
     "fetch_result"
    ]
@@ -766,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 16,
    "id": "hispanic-talent",
    "metadata": {
     "colab": {
@@ -790,7 +836,7 @@
        "{}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -802,7 +848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 17,
    "id": "romantic-dubai",
    "metadata": {
     "colab": {
@@ -823,16 +869,18 @@
     {
      "data": {
       "text/plain": [
-       "FetchResponse(namespace='', vectors={'A': Vector(id='A', values=[0.1, 0.1], metadata=None, sparse_values=None), 'B': Vector(id='B', values=[2.0, 2.0], metadata=None, sparse_values=None)}, usage={'read_units': 1})"
+       "FetchResponse(namespace='', vectors={'B': Vector(id='B', values=[2.0, 2.0], metadata=None, sparse_values=None)}, usage={'read_units': 1})"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Deleted vectors are empty\n",
+    "\n",
+    "time.sleep(5)\n",
     "fetch_results = index.fetch(ids=[\"A\", \"B\"])\n",
     "fetch_results"
    ]
@@ -858,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 18,
    "id": "nonprofit-popularity",
    "metadata": {
     "colab": {
@@ -887,7 +935,7 @@
        " 'vector_type': 'dense'}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -918,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 19,
    "id": "supported-casino",
    "metadata": {
     "id": "supported-casino",
@@ -943,7 +991,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -957,7 +1005,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.10.16"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Problem

The original code was correct, but the output at line 28 was misleading in the file - docs/quick-tour/interacting-with-the-index.ipynb.
Even after calling index.delete(ids=["A"]), the fetch result still included vector "A", which was unexpected. This occurred because vector deletions in the index are not immediately consistent — the deletion may take a few seconds to propagate before being reflected in fetch results.

## Solution

To ensure consistency between delete and fetch operations, I added simple time.sleep() delays after the upsert() and delete() calls. This gives the system enough time to reflect the changes before verifying the result. The core logic remains unchanged, the added delays prevent false negatives in fetch outputs.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

1. Upsert vectors "A" and "B".
2. Sleep briefly to allow for consistency.
3. Verify both vectors appear in fetch results.
4. Delete vector "A".
5. Sleep again to ensure deletion is fully applied.
6. Verify that "A" no longer appears in fetch results, while "B" still does.
7. All steps pass with the added delay, confirming the issue was timing-related rather than a code logic bug.
