### PR TITLE
Fix "pip" collision in workflow script causing normal cells to be filtered out

### DIFF
--- a/.github/actions/run-notebook/convert-notebook.py
+++ b/.github/actions/run-notebook/convert-notebook.py
@@ -70,9 +70,30 @@ print(f"Setup script saved to {run_script_path}")
 
 # Collect cells that are not pip install commands
 executable_cells = ["from IPython.display import display"]
+
+# pip commands we want to ignore:
+
+PIP_COMMANDS = [
+    "pip install",
+    "pip uninstall",
+    "pip freeze",
+    "pip list",
+    "pip show",
+    "pip check",
+    "pip download",
+    "pip config",
+    "pip search",
+    "pip wheel",
+    "pip hash",
+    "pip cache",
+    "pip index"
+]
+
+
 for cell in nb.cells:
     if cell.cell_type == "code":
-        if "pip" not in cell.source:
+        # ensures the cell is not a pip command, avoid hitting words that contain "pip"
+        if not any(cmd in cell.source for cmd in PIP_COMMANDS):
             #  Remove any lines that start with "!" or "%"
             #  These are "magic" commands such as "%matplotlib inline" that 
             #  are not executable outside of a notebook environment.


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?

The convert-notebook script, used in the test notebooks action was failing notebooks that should pass under normal circumstances. The issue was a line in the workflow script that filtered out cells containing the string "pip", which filtered out "pipeline", "pipe", etc.  This can be seen in the following prs:

Instance 1: "pipeline" getting filtered out: https://github.com/pinecone-io/examples/pull/474
Instance 2: "pipe" getting filtered out: https://github.com/pinecone-io/examples/actions/runs/16154448867/job/45593572999?pr=473

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

I added a list of pip commands we'd want to ignore at the relevant level of preprocessing and had the script filter cells with those out, instead of "pip"

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

I'll re-run tests that failed with the old script.
