### PR TITLE
Pinned Numpy Version to avoid conflicts with Datasets in semantic-search notebook

### DIFF
--- a/docs/semantic-search.ipynb
+++ b/docs/semantic-search.ipynb
@@ -95,7 +95,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Pinecone API key not found in environment.\n"
+            "✓ Using API key from environment variable\n"
           ]
         }
       ],

--- a/docs/semantic-search.ipynb
+++ b/docs/semantic-search.ipynb
@@ -34,7 +34,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -47,7 +47,8 @@
         "!uv pip install -qU \\\n",
         "  pinecone~=7.3.0 \\\n",
         "  pinecone-notebooks==0.1.1 \\\n",
-        "  datasets==3.5.1 "
+        "  numpy==2.0.2 \\\n",
+        "  datasets==3.5.1"
       ]
     },
     {


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?

An earlier change to the semantic search notebook broke functionality, by causing a new version of numpy to be installed (2.3.2), which broke the datasets library's install of tatoeba. This commit pins numpy to an earlier version (2.0.2) that allows for the notebook to run as intended.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

I tested between colab and local frequently, and found that colab's UV instance has numpy 2.3.2, whereas their pip instance has 2.0.2. Pip did not experience this issue install when using datasets previously, so I tested pinning the uv install of numpy to 2.0.2, which worked on:
- the colab instance
- an uploaded local instance to colab as well

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

