### PR TITLE
chore(gitignore): ignore agentic harness state directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,15 @@ examples.egg-info/
 .env
 
 bird-search-example-main
+
+# === Harness protection (schema v1) ===
+# These entries prevent agentic harness state files from being
+# accidentally committed to this repository. Do not remove.
+pipeline-state/
+tasks/
+*.rings.toml
+.rings.lock.*
+scratch/
+bootstrap-state/
+playbooks/
+reviewers/


### PR DESCRIPTION
## Purpose

AI-assisted development harnesses for this repo (including the one I'm using to track `python-sdk` updates) maintain state files in directories like `tasks/`, `pipeline-state/`, `scratch/`, `playbooks/`, `reviewers/`, and `bootstrap-state/`. Today, if a contributor uses such a tool and accidentally runs `git add -A` from the wrong working directory, those state files can leak into PRs.

This adds 8 directory/pattern entries to `.gitignore` so those files are excluded by default — defense in depth alongside whatever the contributor's own tooling provides.

## Solution

```
pipeline-state/
tasks/
*.rings.toml
.rings.lock.*
scratch/
bootstrap-state/
playbooks/
reviewers/
```

## Notes

- None of these directory names are currently used anywhere in this repo, so no existing files are affected.
- Header comments label this as `schema v1` so future additions can land cleanly.
- The entries are conservative — only directories/patterns that are unambiguously harness-state artifacts.

## Verification

- [x] `git status` clean in a fresh checkout (no new ignored files)
- [x] No existing tracked files match the new patterns (`git ls-files | grep -E '^(pipeline-state|tasks|scratch|bootstrap-state|playbooks|reviewers)/' → empty`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude harness state directories/patterns, with no runtime or behavioral impact on the codebase.
> 
> **Overview**
> Adds a **"Harness protection (schema v1)"** section to `.gitignore` to prevent accidental commits of agentic harness state artifacts.
> 
> New ignore patterns cover `pipeline-state/`, `tasks/`, `scratch/`, `bootstrap-state/`, `playbooks/`, `reviewers/`, plus `*.rings.toml` and `.rings.lock.*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0a6eeb0a3ef4f363f4ef7a166ca3126d1654a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->