### PR TITLE
refactor(docs/quick-tour): modernize hello-pinecone to pinecone 9.0

### DIFF
--- a/docs/quick-tour/hello-pinecone.ipynb
+++ b/docs/quick-tour/hello-pinecone.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "023d771c",
+   "id": "0",
    "metadata": {
     "id": "023d771c"
    },
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "conceptual-belfast",
+   "id": "1",
    "metadata": {
     "editable": true,
     "id": "conceptual-belfast",
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "first-affairs",
+   "id": "2",
    "metadata": {
     "id": "first-affairs",
     "papermill": {
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "banned-huntington",
+   "id": "3",
    "metadata": {
     "editable": true,
     "id": "banned-huntington",
@@ -76,8 +76,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "parallel-detective",
+   "execution_count": null,
+   "id": "4",
    "metadata": {
     "id": "parallel-detective",
     "papermill": {
@@ -91,12 +91,19 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU pandas==2.2.3 pinecone==8.0.0"
+    "!pip install -qU pandas==2.2.3 pinecone==9.0.0\n",
+    "\n",
+    "import os\n",
+    "import random\n",
+    "import time\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pinecone import AwsRegion, CloudProvider, Metric, Pinecone, ServerlessSpec"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "272f3b6d",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Getting started\n",
@@ -106,14 +113,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "3f53fd40",
+   "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from pinecone import Pinecone\n",
-    "\n",
     "# Get your API key at app.pinecone.io\n",
     "api_key = os.environ.get(\"PINECONE_API_KEY\") or \"PINECONE_API_KEY\"\n",
     "\n",
@@ -123,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "forbidden-indication",
+   "id": "7",
    "metadata": {
     "id": "forbidden-indication",
     "papermill": {
@@ -143,8 +147,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "EA2EcZsCoWS3",
+   "execution_count": null,
+   "id": "8",
    "metadata": {
     "id": "EA2EcZsCoWS3",
     "tags": [
@@ -159,8 +163,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "synthetic-essex",
+   "execution_count": null,
+   "id": "9",
    "metadata": {
     "id": "synthetic-essex",
     "papermill": {
@@ -181,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94LRI2H8Ch2B",
+   "id": "10",
    "metadata": {
     "editable": true,
     "id": "94LRI2H8Ch2B",
@@ -212,8 +216,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "4YwC8livCrn2",
+   "execution_count": null,
+   "id": "11",
    "metadata": {
     "id": "4YwC8livCrn2",
     "papermill": {
@@ -225,39 +229,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{\n",
-       "    \"name\": \"hello-pinecone\",\n",
-       "    \"metric\": \"cosine\",\n",
-       "    \"host\": \"hello-pinecone-dojoi3u.svc.aped-4627-b74a.pinecone.io\",\n",
-       "    \"spec\": {\n",
-       "        \"serverless\": {\n",
-       "            \"cloud\": \"aws\",\n",
-       "            \"region\": \"us-east-1\"\n",
-       "        }\n",
-       "    },\n",
-       "    \"status\": {\n",
-       "        \"ready\": true,\n",
-       "        \"state\": \"Ready\"\n",
-       "    },\n",
-       "    \"vector_type\": \"dense\",\n",
-       "    \"dimension\": 3,\n",
-       "    \"deletion_protection\": \"disabled\",\n",
-       "    \"tags\": null\n",
-       "}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from pinecone import ServerlessSpec, CloudProvider, AwsRegion, Metric\n",
-    "\n",
     "pc.create_index(\n",
     "    name=index_name,\n",
     "    metric=Metric.COSINE,\n",
@@ -268,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "060bb093-fc60-4065-bb6f-529145e6f186",
+   "id": "12",
    "metadata": {},
    "source": [
     "We can look up the configuration for the index anytime we like by using `describe_index`"
@@ -276,39 +249,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "eeb2f680-7250-4117-bdbb-b19fc36d476b",
+   "execution_count": null,
+   "id": "13",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{\n",
-       "    \"name\": \"hello-pinecone\",\n",
-       "    \"metric\": \"cosine\",\n",
-       "    \"host\": \"hello-pinecone-dojoi3u.svc.aped-4627-b74a.pinecone.io\",\n",
-       "    \"spec\": {\n",
-       "        \"serverless\": {\n",
-       "            \"cloud\": \"aws\",\n",
-       "            \"region\": \"us-east-1\"\n",
-       "        }\n",
-       "    },\n",
-       "    \"status\": {\n",
-       "        \"ready\": true,\n",
-       "        \"state\": \"Ready\"\n",
-       "    },\n",
-       "    \"vector_type\": \"dense\",\n",
-       "    \"dimension\": 3,\n",
-       "    \"deletion_protection\": \"disabled\",\n",
-       "    \"tags\": null\n",
-       "}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "description = pc.describe_index(name=index_name)\n",
     "description"
@@ -316,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "j1F8SLx6C2HH",
+   "id": "14",
    "metadata": {
     "id": "j1F8SLx6C2HH",
     "papermill": {
@@ -336,8 +280,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "toy-VhU4LO_O",
+   "execution_count": null,
+   "id": "15",
    "metadata": {
     "id": "toy-VhU4LO_O",
     "papermill": {
@@ -357,8 +301,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "indirect-lafayette",
+   "execution_count": null,
+   "id": "16",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -375,80 +319,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>vector</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>id-0</td>\n",
-       "      <td>[0.19415077620011345, 0.12315138914527213, 0.9...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>id-1</td>\n",
-       "      <td>[0.8274728097660323, 0.8350750339818135, 0.961...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>id-2</td>\n",
-       "      <td>[0.9630530808168708, 0.46559222532176947, 0.04...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>id-3</td>\n",
-       "      <td>[0.5879443851815274, 0.5590457108385455, 0.924...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>id-4</td>\n",
-       "      <td>[0.6104298712136548, 0.2665978264705289, 0.858...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     id                                             vector\n",
-       "0  id-0  [0.19415077620011345, 0.12315138914527213, 0.9...\n",
-       "1  id-1  [0.8274728097660323, 0.8350750339818135, 0.961...\n",
-       "2  id-2  [0.9630530808168708, 0.46559222532176947, 0.04...\n",
-       "3  id-3  [0.5879443851815274, 0.5590457108385455, 0.924...\n",
-       "4  id-4  [0.6104298712136548, 0.2665978264705289, 0.858..."
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import random\n",
-    "import pandas as pd\n",
-    "\n",
     "# Set seed for reproducible results\n",
     "random.seed(42)\n",
     "\n",
@@ -473,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "oiJKXWxoDjhK",
+   "id": "17",
    "metadata": {
     "id": "oiJKXWxoDjhK",
     "papermill": {
@@ -491,8 +363,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "efficient-parliament",
+   "execution_count": null,
+   "id": "18",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -508,26 +380,15 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'upserted_count': 10}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "index.upsert(vectors=zip(df.id, df.vector))  # insert vectors"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "enclosed-performer",
+   "execution_count": null,
+   "id": "19",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -543,27 +404,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  0\n",
-      "Vector count:  10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import time\n",
-    "\n",
     "# Wait for vectors to be indexed and available for querying\n",
     "while index.describe_index_stats().total_vector_count == 0:\n",
     "    time.sleep(1)\n",
@@ -573,8 +415,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "1105937a-e37b-4110-86a8-58ca1bcf9797",
+   "execution_count": null,
+   "id": "20",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -590,23 +432,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 3,\n",
-       " 'index_fullness': 0.0,\n",
-       " 'metric': 'cosine',\n",
-       " 'namespaces': {'': {'vector_count': 10}},\n",
-       " 'total_vector_count': 10,\n",
-       " 'vector_type': 'dense'}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# View index stats\n",
     "index.describe_index_stats()"
@@ -614,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d4b3875-7525-4bc6-835e-8509e46f2c50",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Running a query\n",
@@ -628,8 +454,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "leading-shape",
+   "execution_count": null,
+   "id": "22",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -645,34 +471,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'matches': [{'id': 'id-1',\n",
-       "              'score': 0.997445405,\n",
-       "              'values': [0.827472806, 0.835075, 0.961279154]},\n",
-       "             {'id': 'id-3',\n",
-       "              'score': 0.972650886,\n",
-       "              'values': [0.587944388, 0.559045732, 0.924576044]},\n",
-       "             {'id': 'id-9',\n",
-       "              'score': 0.958372176,\n",
-       "              'values': [0.323696256, 0.569944143, 0.704567373]},\n",
-       "             {'id': 'id-4',\n",
-       "              'score': 0.921065927,\n",
-       "              'values': [0.610429883, 0.266597837, 0.858841419]},\n",
-       "             {'id': 'id-7',\n",
-       "              'score': 0.906878114,\n",
-       "              'values': [0.2434071, 0.738737464, 0.967846]}],\n",
-       " 'namespace': '',\n",
-       " 'usage': {'read_units': 1}}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# In a more realistic scenario, this would be an embedding vector\n",
     "# that encodes something meaningful. For this simple demo, we will\n",
@@ -684,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "z5jcU5_SLMFC",
+   "id": "23",
    "metadata": {
     "id": "z5jcU5_SLMFC",
     "papermill": {
@@ -703,8 +502,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "indian-broadcast",
+   "execution_count": null,
+   "id": "24",
    "metadata": {
     "id": "indian-broadcast",
     "papermill": {
@@ -723,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b60486",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Next steps\n",


### PR DESCRIPTION
## Purpose

hello-pinecone.ipynb pinned `pinecone==8.0.0` (one major version behind) and had
imports scattered across non-first code cells (code cells 2, 5, 8, 10),
failing the `check-structure` validator. Ruff reported `I001` import-sorting
errors in three cells where stdlib and third-party imports were not separated
by a blank line.

## Solution

- `pinecone==8.0.0` → `pinecone==9.0.0` (pip install cell)
- Consolidate all unconditional imports into the first code cell (the pip install
  cell) per `check-structure` requirements: `os`, `random`, `time`, `pandas`,
  and all `pinecone` symbols now live in a single block at the top
- Sort imports: stdlib group (`os`, `random`, `time`) then third-party group
  (`pandas`, pinecone symbols) with a blank line between groups — fixes all
  `I001` findings
- Remove now-redundant import lines from the former code cells 5, 8, and 10
- All Pinecone call sites already used keyword arguments (no positional fixes needed)

## Verification

- [x] Notebook executes top-to-bottom against real Pinecone API
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `check-pinning` passes
- [x] `check-secrets` passes
- [x] `check-structure` passes
- [x] `check-timeless` passes
- [x] No `pinecone.init` / `pinecone-client` / `environment=` patterns remaining
- [x] Cleanup cell (`pc.delete_index(name=index_name)`) executed successfully

## Advisory checks

- Behavior preservation: confirmed — notebook still creates a serverless index,
  upserts 10 simulated vectors, waits for indexing, runs a cosine-similarity
  query, and deletes the index. Output shape and values unchanged.

## Refs

- Harness task: NB-087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates a tutorial notebook’s dependency pin and reorganizes notebook cells/imports without changing the underlying API flow.
> 
> **Overview**
> Updates `docs/quick-tour/hello-pinecone.ipynb` to pin `pinecone==9.0.0` (from 8.x) and consolidates/sorts all imports into the first install cell.
> 
> Cleans the notebook for tooling/validation by clearing execution counts/outputs and normalizing cell `id`s, removing redundant per-cell imports while keeping the index create/upsert/query/delete steps the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9c9a99f6a6d7e35377d694caeed86441769470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->