### PR TITLE
chore: clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .DS_Store
-.__pycache__
+
+# Python build/runtime artifacts
+__pycache__/
+*.pyc
+*.egg-info/
+.venv/
 
 # Data files
 **/*.parquet
@@ -25,11 +30,9 @@ question_answering/tmp
 
 # secrets
 .env
-examples.egg-info/
 
 # worktrees
 .worktrees/
-.env
 
 bird-search-example-main
 


### PR DESCRIPTION
## Summary

Small follow-up to #576. Tidies the `.gitignore`:

- **Add `.venv/`** — currently completely unignored. Anyone running `uv sync` and then `git add .` could commit the venv.
- **Add `__pycache__/` and `*.pyc`** — Python bytecode wasn't ignored at all. The existing `.__pycache__` entry (note the leading dot) was a typo that matches no real Python output.
- **Generalize `examples.egg-info/` → `*.egg-info/`** — so a project rename doesn't quietly reintroduce the leak.
- **Drop the duplicate `.env`** — it was listed twice.
- Group the new Python-artifact entries under a single comment for readability.

No currently-tracked files match the new patterns, so nothing is newly ignored-after-being-tracked.

## Test plan

- [x] `git ls-files | grep -E '(__pycache__|\.pyc$|\.egg-info|\.venv)'` returns nothing — no tracked files affected
- [ ] CI: `lint` green
- [ ] CI: `test-notebooks-changed` no-op (no `.ipynb` changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates ignore patterns and does not affect runtime behavior or shipped code.
> 
> **Overview**
> Cleans up `.gitignore` to better exclude Python build/runtime artifacts by ignoring `__pycache__/`, `*.pyc`, `*.egg-info/`, and `.venv/`, and by removing a typo/duplicate entries.
> 
> Keeps existing data/notebook ignore rules while retaining the harness protection block to prevent committing agent state files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae735657ff1abf9916ae653c394ecbbb50e7affb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->