### PR TITLE
feat: improve semantic search marimo notebook

### DIFF
--- a/docs/semantic-search.py
+++ b/docs/semantic-search.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "datasets",
+#     "datasets==3.5.1",
 #     "marimo>=0.23.6",
 #     "pinecone==9.0.1",
 # ]
@@ -53,17 +53,77 @@ def _(mo):
 
     ### Pinecone API Key
 
-    Set your `PINECONE_API_KEY` environment variable before running this notebook.
-    You can get a free key at [app.pinecone.io](https://app.pinecone.io).
+    You'll need a free Pinecone API key to run this notebook. Get one at
+    [app.pinecone.io](https://app.pinecone.io).
+
+    **Running locally?** Set `PINECONE_API_KEY` in your environment or in a `.env`
+    file — marimo reads `.env` files automatically on startup. The cell below will
+    detect the key and confirm it's loaded.
+
+    **Running in molab?** Enter your key directly in the input field below.
     """)
     return
 
 
-@app.cell
-def _(Pinecone, os):
-    # Initialize client
-    api_key = os.environ.get("PINECONE_API_KEY")
+@app.cell(hide_code=True)
+def _(mo, os):
+    env_key = os.environ.get("PINECONE_API_KEY", "")
 
+    api_key_input = mo.ui.text(
+        kind="password",
+        placeholder="pcsk_...",
+        label="Pinecone API Key",
+        value=env_key,
+        full_width=True,
+    )
+
+    (
+        mo.callout(mo.md("API key loaded from environment."), kind="success")
+        if env_key
+        else mo.vstack(
+            [
+                mo.callout(
+                    mo.md(
+                        "Enter your Pinecone API key. Get a free key at [app.pinecone.io](https://app.pinecone.io)."
+                    ),
+                    kind="info",
+                ),
+                api_key_input,
+            ]
+        )
+    )
+    return (api_key_input,)
+
+
+@app.cell(hide_code=True)
+def _(api_key_input, mo):
+    api_key = api_key_input.value
+    mo.stop(
+        not api_key,
+        mo.callout(
+            mo.md("**API key required.** Enter your key above to continue."),
+            kind="danger",
+        ),
+    )
+    return (api_key,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ### Instantiating the Client
+
+    With the API key in hand, we can create a `Pinecone` client. This is the entry point for all
+    control-plane operations — creating and managing indexes, listing namespaces, and so on.
+
+    The `source_tag` parameter is used internally by Pinecone to attribute API usage from example
+    notebooks. You would not include this in your own applications.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(Pinecone, api_key):
     pc = Pinecone(
         api_key=api_key,
         source_tag="pinecone_examples:docs:semantic_search",


### PR DESCRIPTION
## Summary

Follow-up improvements to the semantic search marimo notebook merged in #581.

## Changes

**Multilingual support**
- Switch embedding model to `multilingual-e5-large` for cross-lingual retrieval
- Embed both English and Spanish sentences from Tatoeba using `filter_pairs` + `extract_sentences(lang)`
- Add cross-lingual query examples and a language filtering section using Pinecone metadata filters

**Interactivity**
- Interactive query input with `mo.ui.text` and `mo.ui.radio` language selector
- Interactive API key input: reads `PINECONE_API_KEY` from env/`.env` with a `mo.ui.text(kind="password")` fallback for molab users; uses `mo.callout` admonitions for each state

**Display**
- Search results rendered as `mo.ui.table` with a `lang` column showing which language each hit came from
- Progress bar via `mo.status.progress_bar` (replacing tqdm)

**Correctness / hygiene**
- Pin `datasets==3.5.1` — `datasets>=4` dropped support for custom loading scripts used by `Helsinki-NLP/tatoeba`
- Use keyword argument names in all Pinecone API calls
- Remove unused `numpy` and `tqdm` dependencies
- Remove notebook-specific deps from root `pyproject.toml` (they belong in the notebook's `# /// script` inline metadata)

## Test Plan

- [ ] Notebook runs end-to-end in sandbox mode (`uvx marimo edit --sandbox`) with a valid `PINECONE_API_KEY`
- [ ] Password input appears when env var is unset; success callout appears when set
- [ ] Cross-lingual queries return results in both English and Spanish
- [ ] Language filter correctly scopes results to `en` or `es`
- [ ] Interactive query input updates results on change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/notebook-only changes that adjust dependency pinning and interactive API key handling; no production code paths affected.
> 
> **Overview**
> Improves the `docs/semantic-search.py` semantic search marimo notebook setup experience by **pinning `datasets==3.5.1`** and replacing the env-only Pinecone key requirement with an **interactive API key input** (env/`.env` auto-detect + password field fallback with callouts).
> 
> Adds a guard (`mo.stop`) to halt execution until a key is provided and introduces a brief section clarifying client instantiation (including the example-only `source_tag`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6da4180b741e3336dc7a221a4b6c6ca9b2a31fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->