### PR TITLE
docs: bump semantic-search + pinecone-quickstart to pinecone 9.1.0

### DIFF
--- a/docs/pinecone-quickstart.ipynb
+++ b/docs/pinecone-quickstart.ipynb
@@ -97,7 +97,11 @@
     "\n",
     "# Initialize a Pinecone client with your API key\n",
     "api_key = os.environ.get(\"PINECONE_API_KEY\")\n",
-    "pc = Pinecone(api_key=api_key)"
+    "pc = Pinecone(\n",
+    "    # You can remove this for your own projects!\n",
+    "    api_key=api_key,\n",
+    "    source_tag=\"pinecone_examples:docs:pinecone_quickstart\",\n",
+    ")" 
    ]
   },
   {

--- a/docs/pinecone-quickstart.ipynb
+++ b/docs/pinecone-quickstart.ipynb
@@ -39,7 +39,7 @@
     "import os\n",
     "import time\n",
     "\n",
-    "from pinecone import Pinecone, SearchQuery, SearchRerank"
+    "from pinecone import Pinecone"
    ]
   },
   {
@@ -504,7 +504,7 @@
     "\n",
     "# Search the dense index\n",
     "results = dense_index.search(\n",
-    "    namespace=\"example-namespace\", query=SearchQuery(top_k=10, inputs={\"text\": query})\n",
+    "    namespace=\"example-namespace\", query={\"top_k\": 10, \"inputs\": {\"text\": query}}\n",
     ")\n",
     "\n",
     "print_results(results)"
@@ -532,10 +532,8 @@
     "# Search the dense index and rerank results\n",
     "reranked_results = dense_index.search(\n",
     "    namespace=\"example-namespace\",\n",
-    "    query=SearchQuery(top_k=10, inputs={\"text\": query}),\n",
-    "    rerank=SearchRerank(\n",
-    "        model=\"bge-reranker-v2-m3\", top_n=10, rank_fields=[\"chunk_text\"]\n",
-    "    ),\n",
+    "    query={\"top_k\": 10, \"inputs\": {\"text\": query}},\n",
+    "    rerank={\"model\": \"bge-reranker-v2-m3\", \"top_n\": 10, \"rank_fields\": [\"chunk_text\"]},\n",
     ")\n",
     "\n",
     "print_results(reranked_results)"

--- a/docs/pinecone-quickstart.ipynb
+++ b/docs/pinecone-quickstart.ipynb
@@ -28,15 +28,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "4SudLike98WL"
    },
    "outputs": [],
    "source": [
-    "!pip install -qU \\\n",
-    "    pinecone==8.0.0 \\\n",
-    "    pinecone-notebooks"
+    "!pip install -qU pinecone==9.1.0 pinecone-notebooks==0.1.1\n",
+    "\n",
+    "import os\n",
+    "import time\n",
+    "\n",
+    "from pinecone import Pinecone, SearchQuery, SearchRerank"
    ]
   },
   {
@@ -54,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -65,8 +68,6 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
     "if not os.environ.get(\"PINECONE_API_KEY\"):\n",
     "    from pinecone_notebooks.colab import Authenticate\n",
     "\n",
@@ -93,7 +94,6 @@
    "outputs": [],
    "source": [
     "# Import the Pinecone library\n",
-    "from pinecone import Pinecone\n",
     "\n",
     "# Initialize a Pinecone client with your API key\n",
     "api_key = os.environ.get(\"PINECONE_API_KEY\")\n",
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "FMyeNo6Afh4z"
    },
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "id": "ZIclo2UK3NFE"
    },
@@ -186,7 +186,7 @@
     "    },\n",
     "    {\n",
     "        \"_id\": \"rec6\",\n",
-    "        \"chunk_text\": \"Water boils at 100\u00b0C under standard atmospheric pressure.\",\n",
+    "        \"chunk_text\": \"Water boils at 100°C under standard atmospheric pressure.\",\n",
     "        \"category\": \"physics\",\n",
     "    },\n",
     "    {\n",
@@ -206,7 +206,7 @@
     "    },\n",
     "    {\n",
     "        \"_id\": \"rec10\",\n",
-    "        \"chunk_text\": \"Newton\u2019s laws describe the motion of objects.\",\n",
+    "        \"chunk_text\": \"Newton’s laws describe the motion of objects.\",\n",
     "        \"category\": \"physics\",\n",
     "    },\n",
     "    {\n",
@@ -425,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "id": "WqDOcyz5gp1Z"
    },
@@ -451,30 +451,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "id": "z3B4RkEqg1US"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 1024,\n",
-       " 'index_fullness': 0.0,\n",
-       " 'metric': 'cosine',\n",
-       " 'namespaces': {'example-namespace': {'vector_count': 50}},\n",
-       " 'total_vector_count': 50,\n",
-       " 'vector_type': 'dense'}"
-      ]
-     },
-     "output_type": "execute_result",
-     "metadata": {},
-     "execution_count": 14
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import time\n",
-    "\n",
     "# Wait for the upserted vectors to be indexed\n",
     "time.sleep(10)\n",
     "\n",
@@ -498,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "id": "Buo2K1h8O_fN"
    },
@@ -507,35 +489,16 @@
     "def print_results(search_results):\n",
     "    for hit in search_results[\"result\"][\"hits\"]:\n",
     "        print(\n",
-    "            f\"id: {hit['_id']:<5} | score: {round(hit['_score'], 3):<5} | category: {hit['fields']['category']:<10} | text: {hit['fields']['chunk_text']:<50}\"\n",
+    "            f\"id: {hit['id']:<5} | score: {round(hit['score'], 3):<5} | category: {hit['fields']['category']:<10} | text: {hit['fields']['chunk_text']:<50}\"\n",
     "        )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "text": [
-      "id: rec17 | score: 0.252 | category: history    | text: The Pyramids of Giza are among the Seven Wonders of the Ancient World.\n",
-      "id: rec5  | score: 0.186 | category: literature | text: Shakespeare wrote many famous plays, including Hamlet and Macbeth.\n",
-      "id: rec38 | score: 0.186 | category: history    | text: The Taj Mahal is a mausoleum built by Emperor Shah Jahan.\n",
-      "id: rec50 | score: 0.098 | category: energy     | text: Renewable energy sources include wind, solar, and hydroelectric power.\n",
-      "id: rec15 | score: 0.096 | category: art        | text: Leonardo da Vinci painted the Mona Lisa.          \n",
-      "id: rec26 | score: 0.084 | category: history    | text: Rome was once the center of a vast empire.        \n",
-      "id: rec1  | score: 0.078 | category: history    | text: The Eiffel Tower was completed in 1889 and stands in Paris, France.\n",
-      "id: rec47 | score: 0.072 | category: history    | text: The Industrial Revolution transformed manufacturing and transportation.\n",
-      "id: rec7  | score: 0.072 | category: history    | text: The Great Wall of China was built to protect against invasions.\n",
-      "id: rec21 | score: 0.061 | category: history    | text: The Statue of Liberty was a gift from France to the United States.\n"
-     ],
-     "name": "stdout"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from pinecone import SearchQuery, SearchRerank\n",
-    "\n",
     "# Define the query\n",
     "query = \"Famous historical structures and monuments\"\n",
     "\n",
@@ -560,28 +523,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "id": "MaqbcsI4I1gU"
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "text": [
-      "id: rec1  | score: 0.107 | category: history    | text: The Eiffel Tower was completed in 1889 and stands in Paris, France.\n",
-      "id: rec38 | score: 0.064 | category: history    | text: The Taj Mahal is a mausoleum built by Emperor Shah Jahan.\n",
-      "id: rec7  | score: 0.063 | category: history    | text: The Great Wall of China was built to protect against invasions.\n",
-      "id: rec21 | score: 0.019 | category: history    | text: The Statue of Liberty was a gift from France to the United States.\n",
-      "id: rec17 | score: 0.015 | category: history    | text: The Pyramids of Giza are among the Seven Wonders of the Ancient World.\n",
-      "id: rec26 | score: 0.011 | category: history    | text: Rome was once the center of a vast empire.        \n",
-      "id: rec15 | score: 0.008 | category: art        | text: Leonardo da Vinci painted the Mona Lisa.          \n",
-      "id: rec5  | score: 0.0   | category: literature | text: Shakespeare wrote many famous plays, including Hamlet and Macbeth.\n",
-      "id: rec47 | score: 0.0   | category: history    | text: The Industrial Revolution transformed manufacturing and transportation.\n",
-      "id: rec50 | score: 0.0   | category: energy     | text: Renewable energy sources include wind, solar, and hydroelectric power.\n"
-     ],
-     "name": "stdout"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Search the dense index and rerank results\n",
     "reranked_results = dense_index.search(\n",
@@ -634,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "id": "1iHV2Y0ujy0y"
    },

--- a/docs/semantic-search.ipynb
+++ b/docs/semantic-search.ipynb
@@ -38,20 +38,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install -qU pinecone==9.1.0 pinecone-notebooks==0.1.1 numpy==2.0.2 datasets==3.5.1\n",
+    "\n",
     "import os\n",
     "\n",
     "from datasets import load_dataset\n",
     "from pinecone import Pinecone\n",
     "from tqdm import tqdm"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install -qU pinecone==8.0.0 pinecone-notebooks==0.1.1 numpy==2.0.2 datasets==3.5.1"
    ]
   },
   {
@@ -148,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -156,23 +149,7 @@
     "id": "kT8pfoO46Iwg",
     "outputId": "0fec19be-c74d-4602-bec6-24d61cfc5bb4"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 1024,\n",
-       " 'index_fullness': 0.0,\n",
-       " 'metric': 'cosine',\n",
-       " 'namespaces': {},\n",
-       " 'total_vector_count': 0,\n",
-       " 'vector_type': 'dense'}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "index_name = \"semantic-search\"\n",
     "\n",
@@ -220,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,32 +220,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': ['0', '1', '2', '3', '4'],\n",
-       " 'translation': [{'en': \"Let's try something.\", 'es': '¡Intentemos algo!'},\n",
-       "  {'en': \"Let's try something.\", 'es': 'Intentemos algo.'},\n",
-       "  {'en': \"Let's try something.\", 'es': 'Permíteme hacer algo.'},\n",
-       "  {'en': \"Let's try something.\", 'es': 'Permíteme intentarlo.'},\n",
-       "  {'en': 'I have to go to sleep.', 'es': 'Tengo que irme a dormir.'}]}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tatoeba[0:5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -376,15 +337,7 @@
     "id": "RhR6WOi1huXZ",
     "outputId": "9ae50bfe-3ebf-4d8b-e28e-3230aed0e1d7"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Upserting records batch: 100%|██████████| 5/5 [00:02<00:00,  1.91it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "batch_size = 96\n",
     "namespace = \"english-sentences\"\n",
@@ -428,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +393,7 @@
     "\n",
     "for result in results[\"result\"][\"hits\"]:\n",
     "    print(\n",
-    "        f\"Sentence: {result['fields']['chunk_text']} Semantic Similarity Score: {result['_score']}\\n\"\n",
+    "        f\"Sentence: {result['fields']['chunk_text']} Semantic Similarity Score: {result['score']}\\n\"\n",
     "    )"
    ]
   },
@@ -453,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +418,7 @@
     "\n",
     "for result in results[\"result\"][\"hits\"]:\n",
     "    print(\n",
-    "        f\"Sentence: {result['fields']['chunk_text']} Semantic Similarity Score: {result['_score']}\\n\"\n",
+    "        f\"Sentence: {result['fields']['chunk_text']} Semantic Similarity Score: {result['score']}\\n\"\n",
     "    )"
    ]
   },
@@ -495,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "id": "-cWdeKzhAtww"
    },


### PR DESCRIPTION
## Why

Continues moving `docs/` off the pre-9.x client (urllib3, no default data-plane timeout). 9.x (httpx) applies a 30s default with retries. Both notebooks were `pinecone==8.0.0`.

## Changes

- Pin bump → `pinecone==9.1.0`; pin `pinecone-notebooks==0.1.1` (was unpinned in pinecone-quickstart).
- **9.x search-hit fix:** `hit['_id']`/`hit['_score']` → `hit['id']`/`hit['score']` (and `result['_score']`). 9.x renames the `Hit` wire fields; only the bracket **reads** change — the 50 `"_id":` **upsert record keys** in pinecone-quickstart are left as-is (the records API still expects `_id`).
- Consolidate imports into the first (pip) cell (`check-structure`), normalized via the repo pre-commit pipeline (`ruff` + `nbstripout`).

`SearchQuery`/`SearchRerank`/`Pinecone` and the integrated `search`/`upsert_records` surface verified present on 9.1.0.

## Verification

All six lint gates pass locally; live `test-notebooks` validates the runtime on this PR — please confirm green before merge.

## Context

Follows #598 (lexical-search) and #599 (quick-tour). The `_id`/`_score` break is systemic across integrated-search notebooks; `gen-qa-openai` and `cascading-retrieval` get the same fix in follow-ups (handled individually — heavier logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook updates with no production code, auth, or data-path changes; runtime behavior depends on CI notebook tests passing on 9.1.0.
> 
> **Overview**
> Updates **`docs/pinecone-quickstart.ipynb`** and **`docs/semantic-search.ipynb`** from `pinecone==8.0.0` to **`pinecone==9.1.0`**, pins **`pinecone-notebooks==0.1.1`**, and aligns both notebooks with the 9.x integrated-search client API.
> 
> **SDK usage:** Search calls drop `SearchQuery` / `SearchRerank` in favor of plain **`query`** and **`rerank`** dicts. Search hit handling switches from **`hit['_id']` / `hit['_score']`** to **`hit['id']` / `hit['score']`** (upsert records still use `"_id"`). The quickstart moves **`os`**, **`time`**, and **`Pinecone`** into the install cell, adds a **`source_tag`** on `Pinecone(...)`, and merges the duplicate pip cell in semantic-search.
> 
> **Notebook hygiene:** Cleared stored outputs and reset **`execution_count`** to null (nbstripout-style), plus minor Unicode fixes in sample strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29f29cd6816b6c4743169086cccd928800c5e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->