### PR TITLE
docs: bump cascading-retrieval to pinecone 9.1.0

### DIFF
--- a/docs/cascading-retrieval.ipynb
+++ b/docs/cascading-retrieval.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -40,19 +40,14 @@
     "id": "rKDBvbjNzqJG",
     "outputId": "11c96b7d-0ce3-48d0-dbf8-3e798fc8bcc9"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -qU \\\n",
-    "  pinecone~=8.0 \\\n",
-    "  pinecone-notebooks==0.1.1"
+    "%pip install -qU pinecone==9.1.0 pinecone-notebooks==0.1.1\n",
+    "\n",
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "from pinecone import Pinecone"
    ]
   },
   {
@@ -81,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "c4SrmHP9IMYO"
    },
@@ -90,7 +85,7 @@
     "def print_hits(results):\n",
     "    for hit in results[\"result\"][\"hits\"]:\n",
     "        print(\n",
-    "            f\"id: {hit['_id']}, score: {round(hit['_score'], 2)} text: {hit['fields']['chunk_text']}\"\n",
+    "            f\"id: {hit['id']}, score: {round(hit['score'], 2)} text: {hit['fields']['chunk_text']}\"\n",
     "        )\n",
     "\n",
     "\n",
@@ -98,16 +93,16 @@
     "    \"\"\"Get the unique hits from two search results and return them as single array of {'_id', 'chunk_text'} dicts, printing each dict on a new line.\"\"\"\n",
     "    # Deduplicate by _id\n",
     "    deduped_hits = {\n",
-    "        hit[\"_id\"]: hit for hit in h1[\"result\"][\"hits\"] + h2[\"result\"][\"hits\"]\n",
+    "        hit[\"id\"]: hit for hit in h1[\"result\"][\"hits\"] + h2[\"result\"][\"hits\"]\n",
     "    }.values()\n",
     "    # Sort by _score descending\n",
-    "    sorted_hits = sorted(deduped_hits, key=lambda x: x[\"_score\"], reverse=True)\n",
+    "    sorted_hits = sorted(deduped_hits, key=lambda x: x[\"score\"], reverse=True)\n",
     "    # Transform to format for reranking\n",
     "    result = [\n",
     "        {\n",
-    "            \"_id\": hit[\"_id\"],\n",
+    "            \"_id\": hit[\"id\"],\n",
     "            \"chunk_text\": hit[\"fields\"][\"chunk_text\"],\n",
-    "            \"_score\": hit[\"_score\"],\n",
+    "            \"_score\": hit[\"score\"],\n",
     "        }\n",
     "        for hit in sorted_hits\n",
     "    ]\n",
@@ -127,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -136,20 +131,8 @@
     "id": "kraDwoDTBQlQ",
     "outputId": "52f267ab-ed79-42b3-8e3a-6b137ab5bef3"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Pinecone API key not found in environment.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
-    "from getpass import getpass\n",
-    "\n",
-    "\n",
     "def get_pinecone_api_key():\n",
     "    \"\"\"\n",
     "    Get Pinecone API key from environment variable or prompt user for input.\n",
@@ -194,14 +177,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "WIqvwOQG3J5_"
    },
    "outputs": [],
    "source": [
-    "from pinecone import Pinecone\n",
-    "\n",
     "# Initialize client\n",
     "\n",
     "pc = Pinecone(\n",
@@ -226,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -234,22 +215,7 @@
     "id": "FHP3-OE4zwmr",
     "outputId": "bd575404-21fc-4d19-95d3-62d75e6eb9aa"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'index_fullness': 0.0,\n",
-       " 'metric': 'dotproduct',\n",
-       " 'namespaces': {},\n",
-       " 'total_vector_count': 0,\n",
-       " 'vector_type': 'sparse'}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sparse_index_name = \"cascading-retrieval-sparse-index\"\n",
     "\n",
@@ -273,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -281,23 +247,7 @@
     "id": "4nZc3kjH4D2m",
     "outputId": "48f3d975-67bd-4dd5-d943-5b8f1ba67e9f"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 1024,\n",
-       " 'index_fullness': 0.0,\n",
-       " 'metric': 'cosine',\n",
-       " 'namespaces': {},\n",
-       " 'total_vector_count': 0,\n",
-       " 'vector_type': 'dense'}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dense_index_name = \"cascading-retrieval-dense-index\"\n",
     "\n",
@@ -331,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "xvNgZb4XK34g"
    },
@@ -729,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "xf1qe2tL0PYf"
    },
@@ -742,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -750,29 +700,14 @@
     "id": "aR4xA1Ou5W_A",
     "outputId": "08804990-20ca-416c-e099-072debd5c9b7"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'index_fullness': 0.0,\n",
-       " 'metric': 'dotproduct',\n",
-       " 'namespaces': {'headlines': {'vector_count': 96}},\n",
-       " 'total_vector_count': 96,\n",
-       " 'vector_type': 'sparse'}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sparse_index.describe_index_stats()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "id": "O2egFf8JG5ih"
    },
@@ -783,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -791,23 +726,7 @@
     "id": "dtx2tVEB6UiC",
     "outputId": "dc47eb45-1611-4999-d70c-7b924d982a48"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 1024,\n",
-       " 'index_fullness': 0.0,\n",
-       " 'metric': 'cosine',\n",
-       " 'namespaces': {'headlines': {'vector_count': 96}},\n",
-       " 'total_vector_count': 96,\n",
-       " 'vector_type': 'dense'}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dense_index.describe_index_stats()"
    ]
@@ -829,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -837,34 +756,7 @@
     "id": "bW16fiUuHdyX",
     "outputId": "731a6c26-3e78-4dd5-a908-32c102b7cf25"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: vec35, score: 0.51 text: Unemployment hit at 2.4% in Q3 of 2024.\n",
-      "id: vec36, score: 0.48 text: Unemployment is expected to hit 2.5% in Q3 of 2024.\n",
-      "id: vec6, score: 0.41 text: Unemployment hit a record low of 3.7% in Q4 of 2024.\n",
-      "id: vec46, score: 0.41 text: Economic recovery in Q2 2024 relied heavily on government spending in infrastructure and green energy projects.\n",
-      "id: vec42, score: 0.41 text: Tech sector layoffs in Q3 2024 have reshaped hiring trends across high-growth industries.\n",
-      "id: vec87, score: 0.4 text: The U.S. labor market's resilience in 2024 defied predictions of a severe recession.\n",
-      "id: vec45, score: 0.36 text: Corporate earnings in Q4 2024 were largely impacted by rising raw material costs and currency fluctuations.\n",
-      "id: vec92, score: 0.36 text: Income inequality widened in 2024 despite strong economic growth in developed nations.\n",
-      "id: vec55, score: 0.35 text: Trade tensions between the U.S. and China escalated in 2024, impacting global supply chains and investment flows.\n",
-      "id: vec94, score: 0.35 text: Cyberattacks targeting financial institutions in 2024 led to record cybersecurity spending.\n",
-      "id: vec48, score: 0.35 text: Wage growth outpaced inflation for the first time in years, signaling improved purchasing power in 2024.\n",
-      "id: vec58, score: 0.35 text: Oil production cuts in Q1 2024 by OPEC nations drove prices higher, influencing global energy policies.\n",
-      "id: vec56, score: 0.35 text: Consumer confidence indices remained resilient in Q2 2024 despite fears of an impending recession.\n",
-      "id: vec62, score: 0.35 text: Private equity activity in 2024 focused on renewable energy and technology sectors amid shifting investor priorities.\n",
-      "id: vec40, score: 0.34 text: Labor market trends show a declining participation rate despite record low unemployment in 2024.\n",
-      "id: vec7, score: 0.34 text: The CPI index rose by 6% in July 2024, raising concerns about purchasing power.\n",
-      "id: vec52, score: 0.34 text: Record-breaking weather events in early 2024 have highlighted the growing economic impact of climate change.\n",
-      "id: vec79, score: 0.33 text: The resurgence of industrial policy in Q1 2024 focused on decoupling critical supply chains.\n",
-      "id: vec13, score: 0.33 text: Credit card APRs reached an all-time high of 22.8% in 2024.\n",
-      "id: vec78, score: 0.33 text: Consumer sentiment surveys in 2024 reflected optimism despite high interest rates.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query = \"Q3 2024 us economic data\"\n",
     "\n",
@@ -877,7 +769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -885,34 +777,7 @@
     "id": "P4rCS-F_MwF-",
     "outputId": "ed37e14d-b8f0-47a7-815d-774c1876bcd4"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "id: vec35, score: 7.06 text: Unemployment hit at 2.4% in Q3 of 2024.\n",
-      "id: vec46, score: 7.04 text: Economic recovery in Q2 2024 relied heavily on government spending in infrastructure and green energy projects.\n",
-      "id: vec36, score: 6.97 text: Unemployment is expected to hit 2.5% in Q3 of 2024.\n",
-      "id: vec42, score: 6.96 text: Tech sector layoffs in Q3 2024 have reshaped hiring trends across high-growth industries.\n",
-      "id: vec49, score: 6.66 text: China's economic growth in 2024 slowed to its lowest level in decades due to structural reforms and weak exports.\n",
-      "id: vec63, score: 6.48 text: Population aging emerged as a critical economic issue in 2024, especially in advanced economies.\n",
-      "id: vec92, score: 5.72 text: Income inequality widened in 2024 despite strong economic growth in developed nations.\n",
-      "id: vec52, score: 5.6 text: Record-breaking weather events in early 2024 have highlighted the growing economic impact of climate change.\n",
-      "id: vec89, score: 4.01 text: Venture capital investments in 2024 leaned heavily toward AI and automation startups.\n",
-      "id: vec62, score: 4.0 text: Private equity activity in 2024 focused on renewable energy and technology sectors amid shifting investor priorities.\n",
-      "id: vec57, score: 3.93 text: Startups in 2024 faced tighter funding conditions as venture capitalists focused on profitability over growth.\n",
-      "id: vec69, score: 3.9 text: The agricultural sector faced challenges in 2024 due to extreme weather and rising input costs.\n",
-      "id: vec37, score: 3.89 text: In Q3 2025 unemployment for the prior year was revised to 2.2%\n",
-      "id: vec60, score: 3.82 text: Healthcare spending in 2024 surged as governments expanded access to preventive care and pandemic preparedness.\n",
-      "id: vec51, score: 3.78 text: The European Union introduced new fiscal policies in 2024 aimed at reducing public debt without stifling growth.\n",
-      "id: vec55, score: 3.77 text: Trade tensions between the U.S. and China escalated in 2024, impacting global supply chains and investment flows.\n",
-      "id: vec70, score: 3.76 text: Consumer spending patterns shifted in 2024, with a greater focus on experiences over goods.\n",
-      "id: vec90, score: 3.71 text: The surge in e-commerce in 2024 was facilitated by advancements in logistics technology.\n",
-      "id: vec87, score: 3.69 text: The U.S. labor market's resilience in 2024 defied predictions of a severe recession.\n",
-      "id: vec78, score: 3.67 text: Consumer sentiment surveys in 2024 reflected optimism despite high interest rates.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sparse_results = sparse_index.search(\n",
     "    namespace=namespace, query={\"top_k\": 20, \"inputs\": {\"text\": query}}\n",
@@ -934,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -942,46 +807,7 @@
     "id": "JhKrGMBcy9qX",
     "outputId": "addf1517-1422-4d6a-d61e-4ee5e53482d9"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Query Q3 2024 us economic data\n",
-      "-----\n",
-      "vec49 - 6.66 - China's economic growth in 2024 slowed to its lowest level in decades due to structural reforms and weak exports.\n",
-      "vec63 - 6.48 - Population aging emerged as a critical economic issue in 2024, especially in advanced economies.\n",
-      "vec89 - 4.01 - Venture capital investments in 2024 leaned heavily toward AI and automation startups.\n",
-      "vec57 - 3.93 - Startups in 2024 faced tighter funding conditions as venture capitalists focused on profitability over growth.\n",
-      "vec69 - 3.9 - The agricultural sector faced challenges in 2024 due to extreme weather and rising input costs.\n",
-      "vec37 - 3.89 - In Q3 2025 unemployment for the prior year was revised to 2.2%\n",
-      "vec60 - 3.82 - Healthcare spending in 2024 surged as governments expanded access to preventive care and pandemic preparedness.\n",
-      "vec51 - 3.78 - The European Union introduced new fiscal policies in 2024 aimed at reducing public debt without stifling growth.\n",
-      "vec70 - 3.76 - Consumer spending patterns shifted in 2024, with a greater focus on experiences over goods.\n",
-      "vec90 - 3.71 - The surge in e-commerce in 2024 was facilitated by advancements in logistics technology.\n",
-      "vec35 - 0.51 - Unemployment hit at 2.4% in Q3 of 2024.\n",
-      "vec36 - 0.48 - Unemployment is expected to hit 2.5% in Q3 of 2024.\n",
-      "vec6 - 0.41 - Unemployment hit a record low of 3.7% in Q4 of 2024.\n",
-      "vec46 - 0.41 - Economic recovery in Q2 2024 relied heavily on government spending in infrastructure and green energy projects.\n",
-      "vec42 - 0.41 - Tech sector layoffs in Q3 2024 have reshaped hiring trends across high-growth industries.\n",
-      "vec87 - 0.4 - The U.S. labor market's resilience in 2024 defied predictions of a severe recession.\n",
-      "vec45 - 0.36 - Corporate earnings in Q4 2024 were largely impacted by rising raw material costs and currency fluctuations.\n",
-      "vec92 - 0.36 - Income inequality widened in 2024 despite strong economic growth in developed nations.\n",
-      "vec55 - 0.35 - Trade tensions between the U.S. and China escalated in 2024, impacting global supply chains and investment flows.\n",
-      "vec94 - 0.35 - Cyberattacks targeting financial institutions in 2024 led to record cybersecurity spending.\n",
-      "vec48 - 0.35 - Wage growth outpaced inflation for the first time in years, signaling improved purchasing power in 2024.\n",
-      "vec58 - 0.35 - Oil production cuts in Q1 2024 by OPEC nations drove prices higher, influencing global energy policies.\n",
-      "vec56 - 0.35 - Consumer confidence indices remained resilient in Q2 2024 despite fears of an impending recession.\n",
-      "vec62 - 0.35 - Private equity activity in 2024 focused on renewable energy and technology sectors amid shifting investor priorities.\n",
-      "vec40 - 0.34 - Labor market trends show a declining participation rate despite record low unemployment in 2024.\n",
-      "vec7 - 0.34 - The CPI index rose by 6% in July 2024, raising concerns about purchasing power.\n",
-      "vec52 - 0.34 - Record-breaking weather events in early 2024 have highlighted the growing economic impact of climate change.\n",
-      "vec79 - 0.33 - The resurgence of industrial policy in Q1 2024 focused on decoupling critical supply chains.\n",
-      "vec13 - 0.33 - Credit card APRs reached an all-time high of 22.8% in 2024.\n",
-      "vec78 - 0.33 - Consumer sentiment surveys in 2024 reflected optimism despite high interest rates.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "merged_results = merge_chunks(sparse_results, dense_results)\n",
     "\n",
@@ -1004,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1012,26 +838,7 @@
     "id": "LPd15tpE-dvF",
     "outputId": "a7f68160-ed5f-4a18-eaa4-0617251caa11"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Query Q3 2024 us economic data\n",
-      "-----\n",
-      "vec36 - 0.84 - Unemployment is expected to hit 2.5% in Q3 of 2024.\n",
-      "vec35 - 0.76 - Unemployment hit at 2.4% in Q3 of 2024.\n",
-      "vec48 - 0.33 - Wage growth outpaced inflation for the first time in years, signaling improved purchasing power in 2024.\n",
-      "vec37 - 0.25 - In Q3 2025 unemployment for the prior year was revised to 2.2%\n",
-      "vec42 - 0.22 - Tech sector layoffs in Q3 2024 have reshaped hiring trends across high-growth industries.\n",
-      "vec87 - 0.21 - The U.S. labor market's resilience in 2024 defied predictions of a severe recession.\n",
-      "vec63 - 0.08 - Population aging emerged as a critical economic issue in 2024, especially in advanced economies.\n",
-      "vec92 - 0.08 - Income inequality widened in 2024 despite strong economic growth in developed nations.\n",
-      "vec46 - 0.06 - Economic recovery in Q2 2024 relied heavily on government spending in infrastructure and green energy projects.\n",
-      "vec6 - 0.06 - Unemployment hit a record low of 3.7% in Q4 of 2024.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "final_results = pc.inference.rerank(\n",
     "    model=\"bge-reranker-v2-m3\",\n",


### PR DESCRIPTION
## Why
Continues the `docs/` migration off the pre-9.x client. Was `pinecone~=8.0`.

## Changes
- Pin → `pinecone==9.1.0`.
- **9.x search-hit fix, surgical.** Only the reads off actual search `Hit` objects are renamed to `["id"]`/`["score"]`: `print_hits`, the dedupe key `hit["_id"]`, and the sort key `x["_score"]`. The `merge_chunks` output dicts deliberately **keep** their `"_id"`/`"_score"` keys, so the downstream `row["_id"]`/`row["_score"]` reads and the `pc.inference.rerank(documents=...)` input are unchanged (a blanket rename would have broken those).
- Normalized via ruff + nbstripout.

## Verification
All six lint gates pass locally; live `test-notebooks` validates the runtime.

Follows #598, #599, #600, #601. This completes the cleanly-bumpable `docs/` set; the remainder is dependency-blocked (langchain-pinecone `<8`, pinecone-datasets `<4`) or requires v3-API rewrites (`pinecone==0.2.13`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook changes with no production code or security impact; behavioral risk is limited to example correctness under the new client.
> 
> **Overview**
> Updates **`docs/cascading-retrieval.ipynb`** for **Pinecone 9.1.0** (from `pinecone~=8.0`), including a pinned install and early `Pinecone` import in the setup cell.
> 
> **9.x search hit shape:** `print_hits` and `merge_chunks` now read **`id`** and **`score`** on API hits (replacing `_id` / `_score`). `merge_chunks` still emits **`_id`** / **`_score`** on its output dicts so merge printing and `pc.inference.rerank(documents=...)` stay unchanged.
> 
> Notebook outputs were cleared (`execution_count: null`, empty `outputs`) via **ruff** and **nbstripout**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefdaf792e8664ca7aa8d1c46d2c7f862587aa37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->