### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/client-versions.yaml
+++ b/.github/workflows/client-versions.yaml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# All jobs only read the checkout; no writes via GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   analyze-client-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+# All jobs only read the checkout; no writes via GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   lint:
     uses: './.github/workflows/lint.yaml'

--- a/.github/workflows/test-notebooks-all.yaml
+++ b/.github/workflows/test-notebooks-all.yaml
@@ -9,6 +9,10 @@ on:
         default: 'docs'
         type: string
 
+# All jobs only read the checkout; no writes via GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-notebooks-changed.yaml
+++ b/.github/workflows/test-notebooks-changed.yaml
@@ -8,6 +8,10 @@ on:
         type: string
         default: 'main'
 
+# All jobs only read the checkout; no writes via GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Resolves all 11 open CodeQL `actions/missing-workflow-permissions` alerts across four workflow files. All workflows only check out the repo and run notebooks/scripts — none make writes via `GITHUB_TOKEN`.

## Changes
- **client-versions.yaml** → `permissions: contents: read`
- **pr.yaml** → `permissions: contents: read`
- **test-notebooks-all.yaml** → `permissions: contents: read`
- **test-notebooks-changed.yaml** → `permissions: contents: read`

## Verification
- YAML parses cleanly (`ruby -ryaml`).
- No behavior change — scoping the token doesn't affect the notebook runs, which use API keys from secrets (not GITHUB_TOKEN).

Part of PIN-16 (security tail), child of PIN-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission tightening with no application or secret-handling changes; notebook runs still use API keys from secrets, not expanded token rights.
> 
> **Overview**
> Adds explicit **`permissions: contents: read`** to four GitHub Actions workflows that previously relied on the default `GITHUB_TOKEN` scope, addressing CodeQL **`actions/missing-workflow-permissions`** findings.
> 
> Affected workflows: **`client-versions.yaml`**, **`pr.yaml`**, **`test-notebooks-all.yaml`**, and **`test-notebooks-changed.yaml`**. Each file also documents that jobs only read the checkout and do not write via `GITHUB_TOKEN`.
> 
> No job logic or triggers change—only token scope is narrowed to match actual usage (checkout, validation, notebook runs using repo secrets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59fda8c3d22a6841169a94becce4af9c2d9e855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->