### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/client-versions.yaml
+++ b/.github/workflows/client-versions.yaml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# Least-privilege default: this report only reads the repo to census notebooks.
+permissions:
+  contents: read
+
 jobs:
   analyze-client-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+# Least-privilege default: lint and notebook tests only read the repo.
+permissions:
+  contents: read
+
 jobs:
   lint:
     uses: './.github/workflows/lint.yaml'

--- a/.github/workflows/test-notebooks-all.yaml
+++ b/.github/workflows/test-notebooks-all.yaml
@@ -9,6 +9,10 @@ on:
         default: 'docs'
         type: string
 
+# Least-privilege default: notebook validation and execution only read the repo.
+permissions:
+  contents: read
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-notebooks-changed.yaml
+++ b/.github/workflows/test-notebooks-changed.yaml
@@ -8,6 +8,10 @@ on:
         type: string
         default: 'main'
 
+# Least-privilege default: change detection and notebook execution only read the repo.
+permissions:
+  contents: read
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a top-level `permissions: contents: read` block to each workflow flagged by the `actions/missing-workflow-permissions` CodeQL rule.

## Why

CodeQL flagged 11 `actions/missing-workflow-permissions` alerts across four workflows. Without an explicit `permissions:` block, jobs run with the repository's default `GITHUB_TOKEN` scopes, which can be broader than needed.

All four workflows are read-only — they check out the repo, run notebooks, or run a version census. None push commits, tags, releases, or comments. `contents: read` is sufficient.

## Files
- `client-versions.yaml` (1 job)
- `pr.yaml` (3 jobs — reusable-workflow caller)
- `test-notebooks-all.yaml` (3 jobs)
- `test-notebooks-changed.yaml` (4 jobs)

## Verification
- YAML parses (`yaml.safe_load`); each file has `permissions: {contents: read}`.

Resolves 11 code-scanning alerts. Mirrors the SDK-tier fix (go-pinecone #146, pinecone-text #99, pinecone-java-client #224).

Refs PIN-24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only scope tightening for read-only CI; risk is low unless a step later needs broader token permissions (not indicated in these workflows).
> 
> **Overview**
> Adds an explicit top-level **`permissions: contents: read`** block (with a short comment) to four GitHub Actions workflows: **client version reporting**, **PR** (caller for lint/notebooks/client-versions), **test all notebooks**, and **test changed notebooks**.
> 
> This narrows the default **`GITHUB_TOKEN`** scope for those runs to repo read access only, addressing CodeQL **`actions/missing-workflow-permissions`** alerts. Behavior is unchanged for these read-only flows (checkout, lint, notebook runs, version census); no jobs in this diff gain write, comment, or release permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d169d2de4d4b75ed93dc2df82bff510b3301b8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->